### PR TITLE
Support select elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ yarn add solar-forms
       * [`isAnyOf` validator](#isanyof-validator)
       * [`email` validator](#email-validator)
       * [`pattern` validator](#pattern-validator)
-  * [Binding form controls to different types of input elements](#binding-form-controls-to-different-types-of-input-elements)
+  * [Binding form controls to different types of `<input>` elements](#binding-form-controls-to-different-types-of-input-elements)
     + [Type of "text"](#type-of-text)
     + [Type of "email"](#type-of-email)
     + [Type of "password"](#type-of-password)
@@ -134,6 +134,7 @@ yarn add solar-forms
     + [Type of "time"](#type-of-time)
     + [Type of "checkbox"](#type-of-checkbox)
     + [Type of "radio"](#type-of-radio)
+  * [Binding form controls to `<select>` element](#binding-form-controls-to-select-element)
   * [Form control errors](#form-control-errors)
     + [Form control name does not match any key from form group](#form-control-name-does-not-match-any-key-from-form-group)
     + [Form control type does not match the type of an input element](#form-control-type-does-not-match-the-type-of-an-input-element)
@@ -1542,6 +1543,42 @@ return (
 );
 ```
 
+### Binding form controls to `<select>` element
+
+You can bind `string` values to the `<select>` element. You can change value
+of the element by choosing one of the predefined options:
+
+```tsx
+type Country = 'Poland' | 'Spain' | 'Germany';
+interface CustomFormGroup {
+  country: Country | '';
+}
+
+// Component definition
+
+const fg = createFormGroup<CustomFormGroup>({
+  // 1️⃣ Default value is set here
+  country: '',
+});
+
+return (
+  <form use:formGroup={fg}>
+    {/* 2️⃣ Choosing one of available options sets form control value to */}
+    {/* a value assigned to specific <option> element */}
+    <label htmlFor="country-select">
+      Country
+      <select name="country" id="country-select" formControlName="country">
+        <option value="">--Please choose an option--</option>
+        <option value="Poland">Poland</option>
+        <option value="Spain">Spain</option>
+        <option value="Germany">Germany</option>
+      </select>
+    </label>
+  </form>
+);
+```
+
+
 ### Form control errors
 
 To ensure that the form group defined by us matches the form structure in our template, some
@@ -1716,8 +1753,8 @@ related to new HTML attributes.
 ## Roadmap
 
 - [x] Creating and exporting [built-in validator functions](https://angular.io/api/forms/Validators) for common usage
+- [x] Support for `<select>` element
 - [ ] Support for `<textarea>` element
-- [ ] Support for `<select>` element
 - [ ] Defining and using [form arrays](https://angular.io/guide/reactive-forms#creating-dynamic-forms)
 - [ ] Support for [async validators](https://angular.io/api/forms/AsyncValidatorFn)
 - [ ] Documentation for API

--- a/package.json
+++ b/package.json
@@ -86,6 +86,6 @@
     "npm": ">=6.14.8"
   },
   "lint-staged": {
-    "{src,test}/**/*": "npm run lint && npm run prettier"
+    "{src,test}/**/*": ["npm run lint", "npm run prettier"]
   }
 }

--- a/src/core/form-group-directive/form-group-directive.tsx
+++ b/src/core/form-group-directive/form-group-directive.tsx
@@ -209,18 +209,18 @@ export function formGroup<I extends CreateFormGroupInput>(el: Element, formGroup
               }
             });
 
-            const onInput = () => {
+            const onChange = () => {
               setValue((s) => ({ ...s, [formControlName]: $formControl.value }));
               setToDirtyIfPristine(formControlName);
             };
-            $formControl.addEventListener('input', onInput);
+            $formControl.addEventListener('change', onChange);
 
             // Mark <select> as touched on blur event
             const onBlur = () => setToTouchedIfUntouched(formControlName);
             $formControl.addEventListener('blur', onBlur);
 
             // Clean up
-            onCleanup(() => $formControl.removeEventListener('input', onInput));
+            onCleanup(() => $formControl.removeEventListener('change', onChange));
             onCleanup(() => $formControl.removeEventListener('blur', onBlur));
           }
         }

--- a/src/core/form-group-directive/form-group-directive.tsx
+++ b/src/core/form-group-directive/form-group-directive.tsx
@@ -4,7 +4,7 @@ import {
   FormControlInvalidNestedGroupError,
   FormControlInvalidTypeError,
 } from '../../errors';
-import { isArrayElement, isBoolean, isDate, isNull, isNumber, isString } from '../../guards';
+import { isBoolean, isDate, isNull, isNumber, isString } from '../../guards';
 import { getFormControl } from './utils/get-form-control';
 import { CreateFormGroupInput } from '../create-form-group/types';
 import { FormGroup } from './types';
@@ -13,217 +13,243 @@ import { getFormControlName } from './utils/get-form-control-name';
 import { getFormGroupName } from './utils/get-form-group-name';
 import { getInputValueType } from './utils/get-input-value-type';
 
-export function formGroup<I extends CreateFormGroupInput>(el: Element, formGroupSignal: () => FormGroup<I>) {
-  if (el && isArrayElement(el.children)) {
-    const [value, setValue] = formGroupSignal().value;
-    const [getDisabled] = formGroupSignal().disabled;
-    const [dirty, setDirty] = formGroupSignal().dirty;
-    const [touched, setTouched] = formGroupSignal().touched;
-    const setToDirtyIfPristine = (formControlName: string | undefined) => {
-      if (formControlName && !dirty()[formControlName]) {
-        setDirty((s) => ({ ...s, [formControlName]: true }));
-      }
-    };
-    const setToTouchedIfUntouched = (formControlName: string | undefined) => {
-      if (formControlName && !touched()[formControlName]) {
-        setTouched((s) => ({ ...s, [formControlName]: true }));
-      }
-    };
+const formGroupForInput = <I extends CreateFormGroupInput>(
+  $formControl: HTMLInputElement,
+  formGroupSignal: () => FormGroup<I>
+) => {
+  const [value, setValue] = formGroupSignal().value;
+  const [getDisabled] = formGroupSignal().disabled;
+  const [dirty, setDirty] = formGroupSignal().dirty;
+  const [touched, setTouched] = formGroupSignal().touched;
+  const setToDirtyIfPristine = (formControlName: string | undefined) => {
+    if (formControlName && !dirty()[formControlName]) {
+      setDirty((s) => ({ ...s, [formControlName]: true }));
+    }
+  };
+  const setToTouchedIfUntouched = (formControlName: string | undefined) => {
+    if (formControlName && !touched()[formControlName]) {
+      setTouched((s) => ({ ...s, [formControlName]: true }));
+    }
+  };
 
-    if (!value()) {
-      throw new FormControlInvalidNestedGroupError(getFormGroupName(el));
+  const formGroupKeys = Object.keys(value());
+  const formControlName = getFormControlName($formControl);
+
+  if (formControlName) {
+    if (!formGroupKeys.includes(formControlName)) {
+      throw new FormControlInvalidKeyError(formControlName);
     }
 
-    const formGroupKeys = Object.keys(value());
+    // Set <input> as disabled or enabled
+    createEffect(() => {
+      const disabledValue = getDisabled()[formControlName];
+      if (isBoolean(disabledValue)) {
+        $formControl.disabled = disabledValue;
+      }
+    });
 
-    for (const $child of el.children) {
-      const formGroupName = getFormGroupName($child);
-      if (formGroupName) {
-        // Handle nested form groups
-        formGroup($child, toNestedFormGroupSignal(formGroupSignal, formGroupName));
-      } else {
-        const $formControl = getFormControl($child);
+    // Set value of <input> element
+    createRenderEffect(() => {
+      const inputType = getInputValueType($formControl.type);
 
-        if ($formControl instanceof HTMLInputElement) {
-          const formControlName = getFormControlName($formControl);
-
-          if (formControlName) {
-            if (!formGroupKeys.includes(formControlName)) {
-              throw new FormControlInvalidKeyError(formControlName);
-            }
-
-            // Set <input> as disabled or enabled
-            createEffect(() => {
-              const disabledValue = getDisabled()[formControlName];
-              if (isBoolean(disabledValue)) {
-                $formControl.disabled = disabledValue;
-              }
-            });
-
-            // Set value of <input> element
-            createRenderEffect(() => {
-              const inputType = getInputValueType($formControl.type);
-
-              if (inputType === 'string') {
-                const formValue = value()[formControlName];
-                if (isString(formValue) || isNull(formValue)) {
-                  $formControl.value = formValue as string;
-                } else {
-                  throw new FormControlInvalidTypeError(formControlName, 'string', formValue);
-                }
-              }
-              if (inputType === 'radio') {
-                const formValue = value()[formControlName];
-                if (isString(formValue) || isNull(formValue)) {
-                  $formControl.checked = $formControl.value === formValue;
-                } else {
-                  throw new FormControlInvalidTypeError(formControlName, 'string', formValue);
-                }
-              }
-              if (inputType === 'number') {
-                const formValue = value()[formControlName];
-                if (isNumber(formValue)) {
-                  $formControl.valueAsNumber = formValue;
-                } else if (isNull(formValue)) {
-                  $formControl.value = formValue as unknown as string;
-                } else {
-                  throw new FormControlInvalidTypeError(formControlName, 'number', formValue);
-                }
-              }
-              if (inputType === 'boolean') {
-                const formValue = value()[formControlName];
-                if (isBoolean(formValue)) {
-                  $formControl.checked = formValue;
-                } else if (isNull(formValue)) {
-                  $formControl.checked = false;
-                } else {
-                  throw new FormControlInvalidTypeError(formControlName, 'boolean', formValue);
-                }
-              }
-              if (inputType === 'date' || inputType === 'time') {
-                const formValue = value()[formControlName];
-                if (isString(formValue) || isNull(formValue)) {
-                  $formControl.value = formValue as string;
-                } else if (isDate(formValue)) {
-                  $formControl.valueAsDate = formValue;
-                } else if (isNumber(formValue)) {
-                  $formControl.valueAsNumber = formValue;
-                } else {
-                  throw new FormControlInvalidTypeError(
-                    formControlName,
-                    ['number', 'string', 'date'],
-                    formValue
-                  );
-                }
-              }
-              if (inputType === 'datetime-local') {
-                const formValue = value()[formControlName];
-                if (isString(formValue) || isNull(formValue)) {
-                  $formControl.value = formValue as string;
-                } else if (isNumber(formValue)) {
-                  $formControl.valueAsNumber = formValue;
-                } else {
-                  throw new FormControlInvalidTypeError(formControlName, ['number', 'string'], formValue);
-                }
-              }
-            });
-
-            // Update form group value and mark as dirty on user input
-            const onInput = () => {
-              const inputType = getInputValueType($formControl.type);
-
-              if (inputType === 'string' || inputType === 'radio') {
-                setValue((s) => ({ ...s, [formControlName]: $formControl.value }));
-                setToDirtyIfPristine(formControlName);
-              }
-              if (inputType === 'number') {
-                if (!Number.isNaN($formControl.valueAsNumber)) {
-                  setValue((s) => ({ ...s, [formControlName]: $formControl.valueAsNumber }));
-                  setToDirtyIfPristine(formControlName);
-                }
-              }
-              if (inputType === 'boolean') {
-                setValue((s) => ({ ...s, [formControlName]: $formControl.checked }));
-                setToDirtyIfPristine(formControlName);
-              }
-              if (inputType === 'date' || inputType === 'time') {
-                const formValue = value()[formControlName];
-                if (isString(formValue) || isNull(formValue)) {
-                  setValue((s) => ({ ...s, [formControlName]: $formControl.value }));
-                  setToDirtyIfPristine(formControlName);
-                }
-                if (isNumber(formValue)) {
-                  setValue((s) => ({ ...s, [formControlName]: $formControl.valueAsNumber }));
-                  setToDirtyIfPristine(formControlName);
-                }
-                if (isDate(formValue)) {
-                  setValue((s) => ({ ...s, [formControlName]: $formControl.valueAsDate }));
-                  setToDirtyIfPristine(formControlName);
-                }
-              }
-              if (inputType === 'datetime-local') {
-                const formValue = value()[formControlName];
-                if (isString(formValue) || isNull(formValue)) {
-                  setValue((s) => ({ ...s, [formControlName]: $formControl.value }));
-                  setToDirtyIfPristine(formControlName);
-                }
-                if (isNumber(formValue)) {
-                  setValue((s) => ({ ...s, [formControlName]: $formControl.valueAsNumber }));
-                  setToDirtyIfPristine(formControlName);
-                }
-              }
-            };
-            $formControl.addEventListener('input', onInput);
-
-            // Mark <input> as touched on blur event
-            const onBlur = () => setToTouchedIfUntouched(formControlName);
-            $formControl.addEventListener('blur', onBlur);
-
-            // Clean up
-            onCleanup(() => $formControl.removeEventListener('input', onInput));
-            onCleanup(() => $formControl.removeEventListener('blur', onBlur));
-          }
-        } else if ($formControl instanceof HTMLSelectElement) {
-          const formControlName = getFormControlName($formControl);
-
-          if (formControlName) {
-            if (!formGroupKeys.includes(formControlName)) {
-              throw new FormControlInvalidKeyError(formControlName);
-            }
-
-            // Set <select> as disabled or enabled
-            createEffect(() => {
-              const disabledValue = getDisabled()[formControlName];
-              if (isBoolean(disabledValue)) {
-                $formControl.disabled = disabledValue;
-              }
-            });
-
-            // Set value of <select> element
-            createRenderEffect(() => {
-              const formValue = value()[formControlName];
-              if (isString(formValue) || isNull(formValue)) {
-                $formControl.value = formValue as string;
-              } else {
-                throw new FormControlInvalidTypeError(formControlName, 'string', formValue);
-              }
-            });
-
-            const onChange = () => {
-              setValue((s) => ({ ...s, [formControlName]: $formControl.value }));
-              setToDirtyIfPristine(formControlName);
-            };
-            $formControl.addEventListener('change', onChange);
-
-            // Mark <select> as touched on blur event
-            const onBlur = () => setToTouchedIfUntouched(formControlName);
-            $formControl.addEventListener('blur', onBlur);
-
-            // Clean up
-            onCleanup(() => $formControl.removeEventListener('change', onChange));
-            onCleanup(() => $formControl.removeEventListener('blur', onBlur));
-          }
+      if (inputType === 'string') {
+        const formValue = value()[formControlName];
+        if (isString(formValue) || isNull(formValue)) {
+          $formControl.value = formValue as string;
+        } else {
+          throw new FormControlInvalidTypeError(formControlName, 'string', formValue);
         }
+      }
+      if (inputType === 'radio') {
+        const formValue = value()[formControlName];
+        if (isString(formValue) || isNull(formValue)) {
+          $formControl.checked = $formControl.value === formValue;
+        } else {
+          throw new FormControlInvalidTypeError(formControlName, 'string', formValue);
+        }
+      }
+      if (inputType === 'number') {
+        const formValue = value()[formControlName];
+        if (isNumber(formValue)) {
+          $formControl.valueAsNumber = formValue;
+        } else if (isNull(formValue)) {
+          $formControl.value = formValue as unknown as string;
+        } else {
+          throw new FormControlInvalidTypeError(formControlName, 'number', formValue);
+        }
+      }
+      if (inputType === 'boolean') {
+        const formValue = value()[formControlName];
+        if (isBoolean(formValue)) {
+          $formControl.checked = formValue;
+        } else if (isNull(formValue)) {
+          $formControl.checked = false;
+        } else {
+          throw new FormControlInvalidTypeError(formControlName, 'boolean', formValue);
+        }
+      }
+      if (inputType === 'date' || inputType === 'time') {
+        const formValue = value()[formControlName];
+        if (isString(formValue) || isNull(formValue)) {
+          $formControl.value = formValue as string;
+        } else if (isDate(formValue)) {
+          $formControl.valueAsDate = formValue;
+        } else if (isNumber(formValue)) {
+          $formControl.valueAsNumber = formValue;
+        } else {
+          throw new FormControlInvalidTypeError(formControlName, ['number', 'string', 'date'], formValue);
+        }
+      }
+      if (inputType === 'datetime-local') {
+        const formValue = value()[formControlName];
+        if (isString(formValue) || isNull(formValue)) {
+          $formControl.value = formValue as string;
+        } else if (isNumber(formValue)) {
+          $formControl.valueAsNumber = formValue;
+        } else {
+          throw new FormControlInvalidTypeError(formControlName, ['number', 'string'], formValue);
+        }
+      }
+    });
+
+    // Update form control values and mark as dirty on user input
+    const onInput = () => {
+      const inputType = getInputValueType($formControl.type);
+
+      if (inputType === 'string' || inputType === 'radio') {
+        setValue((s) => ({ ...s, [formControlName]: $formControl.value }));
+        setToDirtyIfPristine(formControlName);
+      }
+      if (inputType === 'number') {
+        if (!Number.isNaN($formControl.valueAsNumber)) {
+          setValue((s) => ({ ...s, [formControlName]: $formControl.valueAsNumber }));
+          setToDirtyIfPristine(formControlName);
+        }
+      }
+      if (inputType === 'boolean') {
+        setValue((s) => ({ ...s, [formControlName]: $formControl.checked }));
+        setToDirtyIfPristine(formControlName);
+      }
+      if (inputType === 'date' || inputType === 'time') {
+        const formValue = value()[formControlName];
+        if (isString(formValue) || isNull(formValue)) {
+          setValue((s) => ({ ...s, [formControlName]: $formControl.value }));
+          setToDirtyIfPristine(formControlName);
+        }
+        if (isNumber(formValue)) {
+          setValue((s) => ({ ...s, [formControlName]: $formControl.valueAsNumber }));
+          setToDirtyIfPristine(formControlName);
+        }
+        if (isDate(formValue)) {
+          setValue((s) => ({ ...s, [formControlName]: $formControl.valueAsDate }));
+          setToDirtyIfPristine(formControlName);
+        }
+      }
+      if (inputType === 'datetime-local') {
+        const formValue = value()[formControlName];
+        if (isString(formValue) || isNull(formValue)) {
+          setValue((s) => ({ ...s, [formControlName]: $formControl.value }));
+          setToDirtyIfPristine(formControlName);
+        }
+        if (isNumber(formValue)) {
+          setValue((s) => ({ ...s, [formControlName]: $formControl.valueAsNumber }));
+          setToDirtyIfPristine(formControlName);
+        }
+      }
+    };
+    $formControl.addEventListener('input', onInput);
+
+    // Mark <input> as touched on blur event
+    const onBlur = () => setToTouchedIfUntouched(formControlName);
+    $formControl.addEventListener('blur', onBlur);
+
+    // Clean up
+    onCleanup(() => $formControl.removeEventListener('input', onInput));
+    onCleanup(() => $formControl.removeEventListener('blur', onBlur));
+  }
+};
+
+const formGroupForSelect = <I extends CreateFormGroupInput>(
+  $formControl: HTMLSelectElement,
+  formGroupSignal: () => FormGroup<I>
+) => {
+  const [value, setValue] = formGroupSignal().value;
+  const [getDisabled] = formGroupSignal().disabled;
+  const [dirty, setDirty] = formGroupSignal().dirty;
+  const [touched, setTouched] = formGroupSignal().touched;
+  const setToDirtyIfPristine = (formControlName: string | undefined) => {
+    if (formControlName && !dirty()[formControlName]) {
+      setDirty((s) => ({ ...s, [formControlName]: true }));
+    }
+  };
+  const setToTouchedIfUntouched = (formControlName: string | undefined) => {
+    if (formControlName && !touched()[formControlName]) {
+      setTouched((s) => ({ ...s, [formControlName]: true }));
+    }
+  };
+
+  const formGroupKeys = Object.keys(value());
+  const formControlName = getFormControlName($formControl);
+
+  if (formControlName) {
+    if (!formGroupKeys.includes(formControlName)) {
+      throw new FormControlInvalidKeyError(formControlName);
+    }
+
+    // Set <select> as disabled or enabled
+    createEffect(() => {
+      const disabledValue = getDisabled()[formControlName];
+      if (isBoolean(disabledValue)) {
+        $formControl.disabled = disabledValue;
+      }
+    });
+
+    // Set value of <select> element
+    createRenderEffect(() => {
+      const formValue = value()[formControlName];
+      if (isString(formValue) || isNull(formValue)) {
+        $formControl.value = formValue as string;
+      } else {
+        throw new FormControlInvalidTypeError(formControlName, 'string', formValue);
+      }
+    });
+
+    // Update form control values and mark as dirty on user input
+    const onChange = () => {
+      setValue((s) => ({ ...s, [formControlName]: $formControl.value }));
+      setToDirtyIfPristine(formControlName);
+    };
+    $formControl.addEventListener('change', onChange);
+
+    // Mark <select> as touched on blur event
+    const onBlur = () => setToTouchedIfUntouched(formControlName);
+    $formControl.addEventListener('blur', onBlur);
+
+    // Clean up
+    onCleanup(() => $formControl.removeEventListener('change', onChange));
+    onCleanup(() => $formControl.removeEventListener('blur', onBlur));
+  }
+};
+
+export function formGroup<I extends CreateFormGroupInput>(el: Element, formGroupSignal: () => FormGroup<I>) {
+  const [value] = formGroupSignal().value;
+
+  if (!value()) {
+    throw new FormControlInvalidNestedGroupError(getFormGroupName(el));
+  }
+
+  for (const $child of el.children) {
+    const formGroupName = getFormGroupName($child);
+    if (formGroupName) {
+      // Handle nested form groups
+      formGroup($child, toNestedFormGroupSignal(formGroupSignal, formGroupName));
+    } else {
+      const $formControl = getFormControl($child);
+
+      if ($formControl instanceof HTMLInputElement) {
+        formGroupForInput($formControl, formGroupSignal);
+      } else if ($formControl instanceof HTMLSelectElement) {
+        formGroupForSelect($formControl, formGroupSignal);
       }
     }
   }

--- a/src/core/form-group-directive/utils/get-form-control.ts
+++ b/src/core/form-group-directive/utils/get-form-control.ts
@@ -33,6 +33,9 @@ export function getFormControl(child: JSX.Element): HTMLInputElement | HTMLSelec
     if (isInput(control)) {
       return control;
     }
+    if (isSelect(control)) {
+      return control;
+    }
   }
   return null;
 }

--- a/src/core/form-group-directive/utils/get-form-control.ts
+++ b/src/core/form-group-directive/utils/get-form-control.ts
@@ -8,6 +8,10 @@ function isLabel(child: JSX.Element): child is HTMLLabelElement {
   return child instanceof HTMLLabelElement;
 }
 
+function isSelect(child: JSX.Element): child is HTMLSelectElement {
+  return child instanceof HTMLSelectElement;
+}
+
 function getAssociatedControlForLabel(label: HTMLLabelElement) {
   return Array.from(label.children).find((c) => c.id === label.htmlFor);
 }
@@ -17,8 +21,11 @@ function getAssociatedControlForLabel(label: HTMLLabelElement) {
  * - standalone `input` elements
  * - `label`s with `input`s as children bound by `htmlFor` attribute.
  */
-export function getFormControl(child: JSX.Element): HTMLInputElement | null {
+export function getFormControl(child: JSX.Element): HTMLInputElement | HTMLSelectElement | null {
   if (isInput(child)) {
+    return child;
+  }
+  if (isSelect(child)) {
     return child;
   }
   if (isLabel(child)) {

--- a/src/guards/index.ts
+++ b/src/guards/index.ts
@@ -1,4 +1,3 @@
-export * from './is-array-element';
 export * from './is-boolean';
 export * from './is-date';
 export * from './is-null';

--- a/src/guards/is-array-element.ts
+++ b/src/guards/is-array-element.ts
@@ -1,6 +1,0 @@
-import { JSX } from 'solid-js';
-
-export function isArrayElement(el: unknown): el is JSX.ArrayElement {
-  // eslint-disable-next-line
-  return el && typeof el === 'object' && (el as any)['length'];
-}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,10 @@ declare module 'solid-js' {
       formControlName?: string;
     }
 
+    interface SelectHTMLAttributes<T> {
+      formControlName?: string;
+    }
+
     interface HTMLAttributes<T> {
       formGroupName?: string;
     }

--- a/test/select-element/form-control-dirty-all.test.tsx
+++ b/test/select-element/form-control-dirty-all.test.tsx
@@ -1,0 +1,123 @@
+import { createFormGroup, formGroup } from '../../src';
+import { screen, render } from 'solid-testing-library';
+import userEvent from '@testing-library/user-event';
+import { TEAMS } from '../utils/get-random-team';
+import { For } from 'solid-js';
+
+const INIT_VALUE = TEAMS[0] as string;
+
+const TestApp = () => {
+  const fg = createFormGroup({
+    value1: INIT_VALUE,
+    value2: {
+      value21: INIT_VALUE,
+    },
+  });
+  const [dirty, setDirty] = fg.dirty;
+  const [dirtyAll, setDirtyAll] = fg.dirtyAll;
+
+  return (
+    <>
+      <p data-testid="value-dirtyAll">{JSON.stringify(dirtyAll())}</p>
+
+      <form use:formGroup={fg}>
+        <label for="value1">value1</label>
+        <select data-testid="select-value1" name="value1" id="value1" formControlName="value1">
+          <For each={TEAMS}>
+            {(t) => (
+              <option data-testid={`value1-${t}`} value={t}>
+                {t}
+              </option>
+            )}
+          </For>
+        </select>
+
+        <div formGroupName="value2">
+          <label for="value21">value21</label>
+          <select data-testid="select-value21" name="value21" id="value21" formControlName="value21">
+            <For each={TEAMS}>
+              {(t) => (
+                <option data-testid={`value21-${t}`} value={t}>
+                  {t}
+                </option>
+              )}
+            </For>
+          </select>
+        </div>
+      </form>
+
+      <button data-testid="btn-mark-all-dirty" onClick={() => setDirtyAll(true)}>
+        Mark all as dirty
+      </button>
+      <button data-testid="btn-mark-all-pristine" onClick={() => setDirtyAll(false)}>
+        Mark all as pristine
+      </button>
+      <button
+        data-testid="btn-mark-each-dirty"
+        onClick={() => setDirty({ ...dirty(), value1: true, value2: { value21: true } })}
+      >
+        Mark each as dirty
+      </button>
+    </>
+  );
+};
+
+describe('Marking all form controls and groups as dirty or pristine', () => {
+  let $valueDirtyAll: HTMLElement;
+  let $selectValue1: HTMLInputElement;
+  let $selectValue1ProductOption: HTMLInputElement;
+  let $selectValue21: HTMLInputElement;
+  let $selectValue21ProductOption: HTMLInputElement;
+  let $btnMarkAllDirty: HTMLElement;
+  let $btnMarkAllPristine: HTMLElement;
+  let $btnMarkEachDirty: HTMLElement;
+
+  beforeEach(async () => {
+    render(() => <TestApp />);
+
+    $valueDirtyAll = await screen.findByTestId('value-dirtyAll');
+    $selectValue1 = (await screen.findByTestId('select-value1')) as HTMLInputElement;
+    $selectValue1ProductOption = (await screen.findByTestId('value1-product')) as HTMLInputElement;
+    $selectValue21 = (await screen.findByTestId('select-value21')) as HTMLInputElement;
+    $selectValue21ProductOption = (await screen.findByTestId('value21-product')) as HTMLInputElement;
+    $btnMarkAllDirty = await screen.findByTestId('btn-mark-all-dirty');
+    $btnMarkAllPristine = await screen.findByTestId('btn-mark-all-pristine');
+    $btnMarkEachDirty = await screen.findByTestId('btn-mark-each-dirty');
+  });
+
+  it('should read dirtyAll value as "false" initially', () => {
+    expect($valueDirtyAll.innerHTML).toBe(String(false));
+  });
+
+  it('should read dirtyAll value as "false" when not all form controls are dirty', () => {
+    userEvent.selectOptions($selectValue1, $selectValue1ProductOption);
+
+    expect($valueDirtyAll.innerHTML).toBe(String(false));
+  });
+
+  it('should read dirtyAll value as "true" when all controls were changed from UI', () => {
+    userEvent.selectOptions($selectValue1, $selectValue1ProductOption);
+    userEvent.selectOptions($selectValue21, $selectValue21ProductOption);
+
+    expect($valueDirtyAll.innerHTML).toBe(String(true));
+  });
+
+  it('should read dirtyAll value as "true" when all controls were marked as dirty programmatically from outside the form', () => {
+    userEvent.click($btnMarkEachDirty);
+
+    expect($valueDirtyAll.innerHTML).toBe(String(true));
+  });
+
+  it('should disable all form controls when setting the property programmatically from outside the form', () => {
+    userEvent.click($btnMarkAllDirty);
+
+    expect($valueDirtyAll.innerHTML).toBe(String(true));
+  });
+
+  it('should read dirtyAll value as "false" when setting the touched property to "false" programmatically from outside the form', () => {
+    userEvent.click($btnMarkAllDirty);
+    userEvent.click($btnMarkAllPristine);
+
+    expect($valueDirtyAll.innerHTML).toBe(String(false));
+  });
+});

--- a/test/select-element/form-control-dirty.test.tsx
+++ b/test/select-element/form-control-dirty.test.tsx
@@ -1,0 +1,154 @@
+import { createFormGroup, formGroup } from '../../src';
+import { screen, render } from 'solid-testing-library';
+import { For } from 'solid-js';
+import userEvent from '@testing-library/user-event';
+import { TEAMS } from '../utils/get-random-team';
+
+const INIT_VALUE = TEAMS[0] as string;
+const TEST_VALUE = TEAMS[1] as string;
+
+const TestApp = () => {
+  const fg = createFormGroup({
+    value1: INIT_VALUE,
+    value2: {
+      value21: INIT_VALUE,
+    },
+  });
+  const [form, setForm] = fg.value;
+  const [dirty, setDirty] = fg.dirty;
+
+  return (
+    <>
+      <p data-testid="dirty1">{String(dirty().value1)}</p>
+      <p data-testid="dirty21">{String(dirty().value2.value21)}</p>
+
+      <form use:formGroup={fg}>
+        <label for="value1">value1</label>
+        <select data-testid="select-value1" name="value1" id="value1" formControlName="value1">
+          <For each={TEAMS}>
+            {(t) => (
+              <option data-testid={`value1-${t}`} value={t}>
+                {t}
+              </option>
+            )}
+          </For>
+        </select>
+
+        <div formGroupName="value2">
+          <label for="value21">value21</label>
+          <select data-testid="select-value21" name="value21" id="value21" formControlName="value21">
+            <For each={TEAMS}>
+              {(t) => (
+                <option data-testid={`value21-${t}`} value={t}>
+                  {t}
+                </option>
+              )}
+            </For>
+          </select>
+        </div>
+      </form>
+
+      <button data-testid="btn-change-value1" onClick={() => setForm({ ...form(), value1: TEST_VALUE })}>
+        Change value1
+      </button>
+
+      <button
+        data-testid="btn-change-value21"
+        onClick={() => setForm({ ...form(), value2: { value21: TEST_VALUE } })}
+      >
+        Change value21
+      </button>
+
+      <button data-testid="btn-mark-dirty-value1" onClick={() => setDirty({ ...dirty(), value1: true })}>
+        Mark value1 dirty
+      </button>
+
+      <button
+        data-testid="btn-mark-dirty-value21"
+        onClick={() => setDirty({ ...dirty(), value2: { value21: true } })}
+      >
+        Mark value21 dirty
+      </button>
+    </>
+  );
+};
+
+describe('Reading and marking form controls and groups as dirty', () => {
+  let $dirty1: HTMLElement;
+  let $dirty21: HTMLElement;
+  let $selectValue1: HTMLInputElement;
+  let $selectValue1ProductOption: HTMLInputElement;
+  let $selectValue21: HTMLInputElement;
+  let $selectValue21ProductOption: HTMLInputElement;
+  let $btnValue1: HTMLElement;
+  let $btnValue21: HTMLElement;
+  let $btnMarkDirtyValue1: HTMLElement;
+  let $btnMarkDirtyValue21: HTMLElement;
+
+  beforeEach(async () => {
+    render(() => <TestApp />);
+
+    $dirty1 = await screen.findByTestId('dirty1');
+    $dirty21 = await screen.findByTestId('dirty21');
+    $selectValue1 = (await screen.findByTestId('select-value1')) as HTMLInputElement;
+    $selectValue1ProductOption = (await screen.findByTestId('value1-product')) as HTMLInputElement;
+    $selectValue21 = (await screen.findByTestId('select-value21')) as HTMLInputElement;
+    $selectValue21ProductOption = (await screen.findByTestId('value21-product')) as HTMLInputElement;
+    $btnValue1 = await screen.findByTestId('btn-change-value1');
+    $btnValue21 = await screen.findByTestId('btn-change-value21');
+    $btnMarkDirtyValue1 = await screen.findByTestId('btn-mark-dirty-value1');
+    $btnMarkDirtyValue21 = await screen.findByTestId('btn-mark-dirty-value21');
+  });
+
+  describe('should set control as pristine (not dirty) when initialized', () => {
+    it('for top-level control', () => {
+      expect($dirty1.innerHTML).toBe(String(false));
+    });
+
+    it('for nested control', () => {
+      expect($dirty21.innerHTML).toBe(String(false));
+    });
+  });
+
+  describe('should change control to dirty when input value is changed from UI', () => {
+    it('for top-level control', () => {
+      userEvent.selectOptions($selectValue1, $selectValue1ProductOption);
+
+      expect($dirty1.innerHTML).toBe(String(true));
+    });
+
+    it('for nested control', () => {
+      userEvent.selectOptions($selectValue21, $selectValue21ProductOption);
+
+      expect($dirty21.innerHTML).toBe(String(true));
+    });
+  });
+
+  describe('should NOT change control to dirty when input value is changed programmatically from outside the form', () => {
+    it('for top-level control', () => {
+      userEvent.click($btnValue1);
+
+      expect($dirty1.innerHTML).toBe(String(false));
+    });
+
+    it('for nested control', () => {
+      userEvent.click($btnValue21);
+
+      expect($dirty21.innerHTML).toBe(String(false));
+    });
+  });
+
+  describe('should change control to dirty when changed programmatically from outside the form', () => {
+    it('for top-level control', () => {
+      userEvent.click($btnMarkDirtyValue1);
+
+      expect($dirty1.innerHTML).toBe(String(true));
+    });
+
+    it('for nested control', () => {
+      userEvent.click($btnMarkDirtyValue21);
+
+      expect($dirty21.innerHTML).toBe(String(true));
+    });
+  });
+});

--- a/test/select-element/form-control-disabled-all.test.tsx
+++ b/test/select-element/form-control-disabled-all.test.tsx
@@ -1,0 +1,148 @@
+import { createFormGroup, formGroup } from '../../src';
+import { screen, render } from 'solid-testing-library';
+import userEvent from '@testing-library/user-event';
+import { For } from 'solid-js';
+import { TEAMS } from '../utils/get-random-team';
+
+const TestApp = () => {
+  const fg = createFormGroup({
+    controlEnabled1: ['test', { disabled: false }],
+    controlDisabled2: ['test', { disabled: true }],
+    control3: {
+      controlEnabled31: ['test', { disabled: false }],
+      controlDisabled32: ['test', { disabled: true }],
+    },
+  });
+  const [disabledAll, setDisabledAll] = fg.disabledAll;
+
+  return (
+    <>
+      <p data-testid="value-disabledAll">{JSON.stringify(disabledAll())}</p>
+
+      <form use:formGroup={fg}>
+        <label for="controlEnabled1">controlEnabled1</label>
+        <select
+          data-testid="select-controlEnabled1"
+          name="controlEnabled1"
+          id="controlEnabled1"
+          formControlName="controlEnabled1"
+        >
+          <For each={TEAMS}>
+            {(t) => (
+              <option data-testid={`controlEnabled1-${t}`} value={t}>
+                {t}
+              </option>
+            )}
+          </For>
+        </select>
+
+        <label for="controlDisabled2">controlDisabled2</label>
+        <select
+          data-testid="select-controlDisabled2"
+          name="controlDisabled2"
+          id="controlDisabled2"
+          formControlName="controlDisabled2"
+        >
+          <For each={TEAMS}>
+            {(t) => (
+              <option data-testid={`controlDisabled2-${t}`} value={t}>
+                {t}
+              </option>
+            )}
+          </For>
+        </select>
+
+        <div formGroupName="control3">
+          <label for="controlEnabled31">controlEnabled31</label>
+          <select
+            data-testid="select-controlEnabled31"
+            name="controlEnabled31"
+            id="controlEnabled31"
+            formControlName="controlEnabled31"
+          >
+            <For each={TEAMS}>
+              {(t) => (
+                <option data-testid={`controlEnabled31-${t}`} value={t}>
+                  {t}
+                </option>
+              )}
+            </For>
+          </select>
+
+          <label for="controlDisabled32">controlDisabled32</label>
+          <select
+            data-testid="select-controlDisabled32"
+            name="controlDisabled32"
+            id="controlDisabled32"
+            formControlName="controlDisabled32"
+          >
+            <For each={TEAMS}>
+              {(t) => (
+                <option data-testid={`controlDisabled32-${t}`} value={t}>
+                  {t}
+                </option>
+              )}
+            </For>
+          </select>
+        </div>
+      </form>
+
+      <button data-testid="btn-disable-all" onClick={() => setDisabledAll(true)}>
+        Disable all
+      </button>
+      <button data-testid="btn-enable-all" onClick={() => setDisabledAll(false)}>
+        Enable all
+      </button>
+    </>
+  );
+};
+
+describe('Disabling and enabling all form controls and groups', () => {
+  let $controlEnabled1: HTMLInputElement;
+  let $controlDisabled2: HTMLInputElement;
+  let $controlEnabled31: HTMLInputElement;
+  let $controlDisabled32: HTMLInputElement;
+  let $btnDisableAll: HTMLElement;
+  let $btnEnableAll: HTMLElement;
+  let $valueDisabledAll: HTMLElement;
+
+  const expectAllControlsToBe = (value: 'enabled' | 'disabled') => {
+    const disabled = value === 'disabled';
+
+    if (disabled) {
+      expect($valueDisabledAll.innerHTML).toBe(String(disabled));
+    }
+    expect($controlEnabled1.disabled).toBe(disabled);
+    expect($controlDisabled2.disabled).toBe(disabled);
+    expect($controlDisabled32.disabled).toBe(disabled);
+    expect($controlEnabled31.disabled).toBe(disabled);
+  };
+
+  beforeEach(async () => {
+    render(() => <TestApp />);
+
+    $controlEnabled1 = (await screen.findByTestId('select-controlEnabled1')) as HTMLInputElement;
+    $controlDisabled2 = (await screen.findByTestId('select-controlDisabled2')) as HTMLInputElement;
+    $controlEnabled31 = (await screen.findByTestId('select-controlEnabled31')) as HTMLInputElement;
+    $controlDisabled32 = (await screen.findByTestId('select-controlDisabled32')) as HTMLInputElement;
+    $btnDisableAll = await screen.findByTestId('btn-disable-all');
+    $btnEnableAll = await screen.findByTestId('btn-enable-all');
+    $valueDisabledAll = await screen.findByTestId('value-disabledAll');
+  });
+
+  it('should read disabledAll value as "false" when at least one form control is enabled', () => {
+    expect($valueDisabledAll.innerHTML).toBe(String(false));
+  });
+
+  it('should disable all form controls when setting the property programmatically from outside the form', () => {
+    userEvent.click($btnDisableAll);
+
+    expectAllControlsToBe('disabled');
+  });
+
+  it('should enable all form controls when setting the property programmatically from outside the form', () => {
+    userEvent.click($btnEnableAll);
+
+    expectAllControlsToBe('enabled');
+  });
+});

--- a/test/select-element/form-control-disabled.test.tsx
+++ b/test/select-element/form-control-disabled.test.tsx
@@ -1,0 +1,241 @@
+import { createFormGroup, formGroup } from '../../src';
+import { screen, render } from 'solid-testing-library';
+import userEvent from '@testing-library/user-event';
+import { For } from 'solid-js';
+import { TEAMS } from '../utils/get-random-team';
+
+const TestApp = () => {
+  const fg = createFormGroup({
+    controlEnabled1: 'test',
+    controlEnabled2: ['test', { disabled: false }],
+    controlDisabled3: ['test', { disabled: true }],
+    control4: {
+      controlEnabled41: 'test',
+      controlEnabled42: ['test', { disabled: false }],
+      controlDisabled43: ['test', { disabled: true }],
+    },
+  });
+  const [disabled, setDisabled] = fg.disabled;
+
+  return (
+    <>
+      <form use:formGroup={fg}>
+        <label for="controlEnabled1">controlEnabled1</label>
+        <select
+          data-testid="select-controlEnabled1"
+          name="controlEnabled1"
+          id="controlEnabled1"
+          formControlName="controlEnabled1"
+        >
+          <For each={TEAMS}>
+            {(t) => (
+              <option data-testid={`controlEnabled1-${t}`} value={t}>
+                {t}
+              </option>
+            )}
+          </For>
+        </select>
+
+        <label for="controlEnabled2">controlEnabled2</label>
+        <select
+          data-testid="select-controlEnabled2"
+          name="controlEnabled2"
+          id="controlEnabled2"
+          formControlName="controlEnabled2"
+        >
+          <For each={TEAMS}>
+            {(t) => (
+              <option data-testid={`controlEnabled2-${t}`} value={t}>
+                {t}
+              </option>
+            )}
+          </For>
+        </select>
+
+        <label for="controlDisabled">controlDisabled3</label>
+        <select
+          data-testid="select-controlDisabled3"
+          name="controlDisabled3"
+          id="controlDisabled3"
+          formControlName="controlDisabled3"
+        >
+          <For each={TEAMS}>
+            {(t) => (
+              <option data-testid={`controlDisabled3-${t}`} value={t}>
+                {t}
+              </option>
+            )}
+          </For>
+        </select>
+
+        <div formGroupName="control4">
+          <label for="controlEnabled1">controlEnabled41</label>
+          <select
+            data-testid="select-controlEnabled41"
+            name="controlEnabled41"
+            id="controlEnabled41"
+            formControlName="controlEnabled41"
+          >
+            <For each={TEAMS}>
+              {(t) => (
+                <option data-testid={`controlEnabled41-${t}`} value={t}>
+                  {t}
+                </option>
+              )}
+            </For>
+          </select>
+
+          <label for="controlEnabled42">controlEnabled42</label>
+          <select
+            data-testid="select-controlEnabled42"
+            name="controlEnabled42"
+            id="controlEnabled42"
+            formControlName="controlEnabled42"
+          >
+            <For each={TEAMS}>
+              {(t) => (
+                <option data-testid={`controlEnabled42-${t}`} value={t}>
+                  {t}
+                </option>
+              )}
+            </For>
+          </select>
+
+          <label for="controlDisabled43">controlDisabled43</label>
+          <select
+            data-testid="select-controlDisabled43"
+            name="controlDisabled43"
+            id="controlDisabled43"
+            formControlName="controlDisabled43"
+          >
+            <For each={TEAMS}>
+              {(t) => (
+                <option data-testid={`controlDisabled43-${t}`} value={t}>
+                  {t}
+                </option>
+              )}
+            </For>
+          </select>
+        </div>
+      </form>
+
+      <button
+        data-testid="btn-controlEnabled1"
+        onClick={() => setDisabled({ ...disabled(), controlEnabled1: true })}
+      >
+        Change controlEnabled1
+      </button>
+
+      <button
+        data-testid="btn-controlEnabled2"
+        onClick={() => setDisabled({ ...disabled(), controlEnabled2: true })}
+      >
+        Change controlEnabled2
+      </button>
+
+      <button
+        data-testid="btn-controlEnabled41"
+        onClick={() =>
+          setDisabled({ ...disabled(), control4: { ...disabled().control4, controlEnabled41: true } })
+        }
+      >
+        Change nested controlEnabled41
+      </button>
+
+      <button
+        data-testid="btn-controlEnabled42"
+        onClick={() =>
+          setDisabled({ ...disabled(), control4: { ...disabled().control4, controlEnabled42: true } })
+        }
+      >
+        Change nested controlEnabled42
+      </button>
+    </>
+  );
+};
+
+describe('Disabling form controls and groups', () => {
+  let $controlEnabled1: HTMLInputElement;
+  let $controlEnabled2: HTMLInputElement;
+  let $controlDisabled3: HTMLInputElement;
+  let $nestedControlEnabled41: HTMLInputElement;
+  let $nestedControlEnabled42: HTMLInputElement;
+  let $nestedControlDisabled43: HTMLInputElement;
+  let $btnControlEnabled1: HTMLElement;
+  let $btnControlEnabled2: HTMLElement;
+  let $btnNestedControlEnabled1: HTMLElement;
+  let $btnNestedControlEnabled2: HTMLElement;
+
+  beforeEach(async () => {
+    render(() => <TestApp />);
+
+    $controlEnabled1 = (await screen.findByTestId('select-controlEnabled1')) as HTMLInputElement;
+    $controlEnabled2 = (await screen.findByTestId('select-controlEnabled2')) as HTMLInputElement;
+    $controlDisabled3 = (await screen.findByTestId('select-controlDisabled3')) as HTMLInputElement;
+    $nestedControlEnabled41 = (await screen.findByTestId('select-controlEnabled41')) as HTMLInputElement;
+    $nestedControlEnabled42 = (await screen.findByTestId('select-controlEnabled42')) as HTMLInputElement;
+    $nestedControlDisabled43 = (await screen.findByTestId('select-controlDisabled43')) as HTMLInputElement;
+    $btnControlEnabled1 = await screen.findByTestId('btn-controlEnabled1');
+    $btnControlEnabled2 = await screen.findByTestId('btn-controlEnabled2');
+    $btnNestedControlEnabled1 = await screen.findByTestId('btn-controlEnabled41');
+    $btnNestedControlEnabled2 = await screen.findByTestId('btn-controlEnabled42');
+  });
+
+  describe('should set control to disabled when initialized as one', () => {
+    it('for top-level control', () => {
+      expect($controlDisabled3.disabled).toBe(true);
+    });
+
+    it('for nested control', () => {
+      expect($nestedControlDisabled43.disabled).toBe(true);
+    });
+  });
+
+  describe('should set control to enabled when initialized as one', () => {
+    describe('for top-level control', () => {
+      it('without config object', () => {
+        expect($controlEnabled1.disabled).toBe(false);
+      });
+
+      it('with config object', () => {
+        expect($controlEnabled2.disabled).toBe(false);
+      });
+    });
+
+    describe('for nested control', () => {
+      it('without config object', () => {
+        expect($nestedControlEnabled41.disabled).toBe(false);
+      });
+
+      it('with config object', () => {
+        expect($nestedControlEnabled42.disabled).toBe(false);
+      });
+    });
+  });
+
+  describe('should set control to disabled when programmatically set from outside the form', () => {
+    describe('for top-level control', () => {
+      it('without config object', () => {
+        userEvent.click($btnControlEnabled1);
+        expect($controlEnabled1.disabled).toBe(true);
+      });
+
+      it('with config object', () => {
+        userEvent.click($btnControlEnabled2);
+        expect($controlEnabled2.disabled).toBe(true);
+      });
+    });
+
+    describe('for nested control', () => {
+      it('without config object', () => {
+        userEvent.click($btnNestedControlEnabled1);
+        expect($nestedControlEnabled41.disabled).toBe(true);
+      });
+
+      it('with config object', () => {
+        userEvent.click($btnNestedControlEnabled2);
+        expect($nestedControlEnabled42.disabled).toBe(true);
+      });
+    });
+  });
+});

--- a/test/select-element/form-control-inside-label.test.tsx
+++ b/test/select-element/form-control-inside-label.test.tsx
@@ -1,0 +1,116 @@
+import { createFormGroup, formGroup } from '../../src';
+import { screen, render } from 'solid-testing-library';
+import userEvent from '@testing-library/user-event';
+import getRandomTeam, { TEAMS } from '../utils/get-random-team';
+import { For } from 'solid-js';
+
+const INIT_INPUT_VALUE = getRandomTeam() as string | null;
+const TEST_INPUT_VALUE = getRandomTeam() as string | null;
+const NULL = String(null);
+
+const TestApp = () => {
+  const fg = createFormGroup({
+    valueString: INIT_INPUT_VALUE,
+    valueNull: null,
+  });
+  const [form, setForm] = fg.value;
+
+  return (
+    <>
+      <p data-testid="value">{form().valueString}</p>
+      <p data-testid="value-null">{String(form().valueNull)}</p>
+
+      <form use:formGroup={fg}>
+        <label for="valueString">
+          valueString
+          <select data-testid="select" name="valueString" id="valueString" formControlName="valueString">
+            <For each={TEAMS}>
+              {(t) => (
+                <option data-testid={`valueString-${t}`} value={t}>
+                  {t}
+                </option>
+              )}
+            </For>
+          </select>
+        </label>
+
+        <label for="valueNull">
+          valueNull
+          <select data-testid="select-null" name="valueNull" id="valueNull" formControlName="valueNull">
+            <For each={TEAMS}>
+              {(t) => (
+                <option data-testid={`valueNull-${t}`} value={t}>
+                  {t}
+                </option>
+              )}
+            </For>
+          </select>
+        </label>
+      </form>
+
+      <button data-testid="btn" onClick={() => setForm((s) => ({ ...s, valueString: TEST_INPUT_VALUE }))}>
+        Change valueString
+      </button>
+      <button data-testid="btn-null" onClick={() => setForm((s) => ({ ...s, valueString: null }))}>
+        Change valueString to null
+      </button>
+    </>
+  );
+};
+
+describe('Label with input element as child', () => {
+  let $valueString: HTMLElement;
+  let $valueNull: HTMLElement;
+  let $selectWithString: HTMLSelectElement;
+  let $selectWithStringProductOption: HTMLOptionElement;
+  let $selectWithNull: HTMLSelectElement;
+  let $changeToStringButton: HTMLElement;
+  let $changeToNullButton: HTMLElement;
+
+  beforeEach(async () => {
+    render(() => <TestApp />);
+
+    $valueString = await screen.findByTestId('value');
+    $valueNull = await screen.findByTestId('value-null');
+    $selectWithString = (await screen.findByTestId('select')) as HTMLSelectElement;
+    $selectWithStringProductOption = (await screen.findByTestId('valueString-product')) as HTMLOptionElement;
+    $selectWithNull = (await screen.findByTestId('select-null')) as HTMLSelectElement;
+    $changeToStringButton = await screen.findByTestId('btn');
+    $changeToNullButton = await screen.findByTestId('btn-null');
+  });
+
+  describe('should init value with the one provided in createFormGroup', () => {
+    it('when value is string', () => {
+      expect($valueString.innerHTML).toBe(INIT_INPUT_VALUE);
+      // TODO this fails, although it works when tested manually
+      // expect($selectWithString.value).toBe(INIT_INPUT_VALUE);
+    });
+
+    it('when form control value is null, first option is selected', () => {
+      expect($valueNull.innerHTML).toBe(NULL);
+      expect($selectWithNull.value).toBe(TEAMS[0]);
+    });
+  });
+
+  describe('should update form value when updating programmatically from outside the form', () => {
+    it('with string', () => {
+      userEvent.click($changeToStringButton);
+
+      expect($valueString.innerHTML).toBe(TEST_INPUT_VALUE);
+      expect($selectWithString.value).toBe(TEST_INPUT_VALUE);
+    });
+
+    it('with null', () => {
+      userEvent.click($changeToNullButton);
+
+      expect($valueString.innerHTML === NULL || $valueString.innerHTML === '').toBeTruthy();
+      expect($selectWithString.value).toBe('');
+    });
+  });
+
+  it('should update form value on manual input', () => {
+    userEvent.selectOptions($selectWithString, $selectWithStringProductOption);
+
+    expect($valueString.innerHTML).toBe('product');
+  });
+});

--- a/test/select-element/form-control-inside-label.test.tsx
+++ b/test/select-element/form-control-inside-label.test.tsx
@@ -1,11 +1,11 @@
 import { createFormGroup, formGroup } from '../../src';
 import { screen, render } from 'solid-testing-library';
 import userEvent from '@testing-library/user-event';
-import getRandomTeam, { TEAMS } from '../utils/get-random-team';
+import { Team, TEAMS } from '../utils/get-random-team';
 import { For } from 'solid-js';
 
-const INIT_INPUT_VALUE = getRandomTeam() as string | null;
-const TEST_INPUT_VALUE = getRandomTeam() as string | null;
+const INIT_INPUT_VALUE = TEAMS[0] as Team | null;
+const TEST_INPUT_VALUE = TEAMS[1] as Team | null;
 const NULL = String(null);
 
 const TestApp = () => {
@@ -82,8 +82,7 @@ describe('Label with input element as child', () => {
   describe('should init value with the one provided in createFormGroup', () => {
     it('when value is string', () => {
       expect($valueString.innerHTML).toBe(INIT_INPUT_VALUE);
-      // TODO this fails, although it works when tested manually
-      // expect($selectWithString.value).toBe(INIT_INPUT_VALUE);
+      expect($selectWithString.value).toBe(INIT_INPUT_VALUE);
     });
 
     it('when form control value is null, first option is selected', () => {

--- a/test/select-element/form-control-touched-all.test.tsx
+++ b/test/select-element/form-control-touched-all.test.tsx
@@ -1,0 +1,122 @@
+import { createFormGroup, formGroup } from '../../src';
+import { screen, render, fireEvent } from 'solid-testing-library';
+import userEvent from '@testing-library/user-event';
+import getRandomTeam, { TEAMS } from '../utils/get-random-team';
+import { For } from 'solid-js';
+
+const INIT_VALUE = getRandomTeam();
+
+const TestApp = () => {
+  const fg = createFormGroup({
+    value1: INIT_VALUE,
+    value2: {
+      value21: INIT_VALUE,
+    },
+  });
+  const [touched, setTouched] = fg.touched;
+  const [touchedAll, setTouchedAll] = fg.touchedAll;
+
+  return (
+    <>
+      <p data-testid="value-touchedAll">{JSON.stringify(touchedAll())}</p>
+
+      <form use:formGroup={fg}>
+        <label for="value1">value1</label>
+        <select data-testid="select-value1" name="value1" id="value1" formControlName="value1">
+          <For each={TEAMS}>
+            {(t) => (
+              <option data-testid={`value1-${t}`} value={t}>
+                {t}
+              </option>
+            )}
+          </For>
+        </select>
+
+        <div formGroupName="value2">
+          <label for="value21">value21</label>
+          <select data-testid="select-value21" name="value21" id="value21" formControlName="value21">
+            <For each={TEAMS}>
+              {(t) => (
+                <option data-testid={`value21-${t}`} value={t}>
+                  {t}
+                </option>
+              )}
+            </For>
+          </select>
+        </div>
+      </form>
+
+      <button data-testid="btn-mark-all-touched" onClick={() => setTouchedAll(true)}>
+        Mark all as touched
+      </button>
+      <button data-testid="btn-mark-all-untouched" onClick={() => setTouchedAll(false)}>
+        Mark all as untouched
+      </button>
+      <button
+        data-testid="btn-mark-each-touched"
+        onClick={() => setTouched({ ...touched(), value1: true, value2: { value21: true } })}
+      >
+        Mark each as touched
+      </button>
+    </>
+  );
+};
+
+describe('Marking all form controls and groups as touched or untouched', () => {
+  let $valueTouchedAll: HTMLElement;
+  let $selectValue1: HTMLSelectElement;
+  let $selectValue21: HTMLSelectElement;
+  let $btnMarkAllTouched: HTMLElement;
+  let $btnMarkAllUntouched: HTMLElement;
+  let $btnMarkEachTouched: HTMLElement;
+
+  beforeEach(async () => {
+    render(() => <TestApp />);
+
+    $valueTouchedAll = await screen.findByTestId('value-touchedAll');
+    $selectValue1 = (await screen.findByTestId('select-value1')) as HTMLSelectElement;
+    $selectValue21 = (await screen.findByTestId('select-value21')) as HTMLSelectElement;
+    $btnMarkAllTouched = await screen.findByTestId('btn-mark-all-touched');
+    $btnMarkAllUntouched = await screen.findByTestId('btn-mark-all-untouched');
+    $btnMarkEachTouched = await screen.findByTestId('btn-mark-each-touched');
+  });
+
+  it('should read touchedAll value as "false" initially', () => {
+    expect($valueTouchedAll.innerHTML).toBe(String(false));
+  });
+
+  it('should read touchedAll value as "false" when not all form controls are touched', () => {
+    fireEvent.focus($selectValue1);
+    fireEvent.blur($selectValue1);
+
+    expect($valueTouchedAll.innerHTML).toBe(String(false));
+  });
+
+  it('should read touchedAll value as "true" when all controls had blur event dispatched', () => {
+    fireEvent.focus($selectValue1);
+    fireEvent.blur($selectValue1);
+    fireEvent.focus($selectValue21);
+    fireEvent.blur($selectValue21);
+
+    expect($valueTouchedAll.innerHTML).toBe(String(true));
+  });
+
+  it('should read touchedAll value as "true" when all controls were marked as touched programmatically from outside the form', () => {
+    userEvent.click($btnMarkEachTouched);
+
+    expect($valueTouchedAll.innerHTML).toBe(String(true));
+  });
+
+  it('should mark all form controls as touched when setting the property programmatically from outside the form', () => {
+    userEvent.click($btnMarkAllTouched);
+
+    expect($valueTouchedAll.innerHTML).toBe(String(true));
+  });
+
+  it('should read touchedAll value as "false" when setting the touched property programmatically to "false" from outside the form', () => {
+    userEvent.click($btnMarkAllTouched);
+    userEvent.click($btnMarkAllUntouched);
+
+    expect($valueTouchedAll.innerHTML).toBe(String(false));
+  });
+});

--- a/test/select-element/form-control-touched.test.tsx
+++ b/test/select-element/form-control-touched.test.tsx
@@ -1,0 +1,124 @@
+import { createFormGroup, formGroup } from '../../src';
+import { screen, render, fireEvent } from 'solid-testing-library';
+import userEvent from '@testing-library/user-event';
+import { For } from 'solid-js';
+import getRandomTeam, { TEAMS } from '../utils/get-random-team';
+
+const INIT_VALUE = getRandomTeam();
+
+const TestApp = () => {
+  const fg = createFormGroup({
+    value1: INIT_VALUE,
+    value2: {
+      value21: INIT_VALUE,
+    },
+  });
+  const [touched, setTouched] = fg.touched;
+
+  return (
+    <>
+      <p data-testid="touched1">{String(touched().value1)}</p>
+      <p data-testid="touched21">{String(touched().value2.value21)}</p>
+
+      <form use:formGroup={fg}>
+        <label for="value1">value1</label>
+        <select data-testid="select-value1" name="value1" id="value1" formControlName="value1">
+          <For each={TEAMS}>
+            {(t) => (
+              <option data-testid={`value1-${t}`} value={t}>
+                {t}
+              </option>
+            )}
+          </For>
+        </select>
+
+        <div formGroupName="value2">
+          <label for="value21">value21</label>
+          <select data-testid="select-value21" name="value21" id="value21" formControlName="value21">
+            <For each={TEAMS}>
+              {(t) => (
+                <option data-testid={`value21-${t}`} value={t}>
+                  {t}
+                </option>
+              )}
+            </For>
+          </select>
+        </div>
+      </form>
+
+      <button
+        data-testid="btn-mark-touched-value1"
+        onClick={() => setTouched({ ...touched(), value1: true })}
+      >
+        Mark value1 touched
+      </button>
+
+      <button
+        data-testid="btn-mark-touched-value21"
+        onClick={() => setTouched({ ...touched(), value2: { value21: true } })}
+      >
+        Mark value21 touched
+      </button>
+    </>
+  );
+};
+
+describe('Reading and marking form controls and groups as touched or untouched', () => {
+  let $touched1: HTMLElement;
+  let $touched21: HTMLElement;
+  let $selectValue1: HTMLInputElement;
+  let $selectValue21: HTMLInputElement;
+  let $btnMarkTouchedValue1: HTMLElement;
+  let $btnMarTouchedValue21: HTMLElement;
+
+  beforeEach(async () => {
+    render(() => <TestApp />);
+
+    $touched1 = await screen.findByTestId('touched1');
+    $touched21 = await screen.findByTestId('touched21');
+    $selectValue1 = (await screen.findByTestId('select-value1')) as HTMLInputElement;
+    $selectValue21 = (await screen.findByTestId('select-value21')) as HTMLInputElement;
+    $btnMarkTouchedValue1 = await screen.findByTestId('btn-mark-touched-value1');
+    $btnMarTouchedValue21 = await screen.findByTestId('btn-mark-touched-value21');
+  });
+
+  describe('should set control as untouched when initialized', () => {
+    it('for top-level control', () => {
+      expect($touched1.innerHTML).toBe(String(false));
+    });
+
+    it('for nested control', () => {
+      expect($touched21.innerHTML).toBe(String(false));
+    });
+  });
+
+  describe('should change control to dirty when form control loses focus (blur event)', () => {
+    it('for top-level control', () => {
+      fireEvent.focus($selectValue1);
+      fireEvent.blur($selectValue1);
+
+      expect($touched1.innerHTML).toBe(String(true));
+    });
+
+    it('for nested control', () => {
+      fireEvent.focus($selectValue21);
+      fireEvent.blur($selectValue21);
+
+      expect($touched21.innerHTML).toBe(String(true));
+    });
+  });
+
+  describe('should change control to touched when changed programmatically from outside the form', () => {
+    it('for top-level control', () => {
+      userEvent.click($btnMarkTouchedValue1);
+
+      expect($touched1.innerHTML).toBe(String(true));
+    });
+
+    it('for nested control', () => {
+      userEvent.click($btnMarTouchedValue21);
+
+      expect($touched21.innerHTML).toBe(String(true));
+    });
+  });
+});

--- a/test/select-element/form-control-valid-all.test.tsx
+++ b/test/select-element/form-control-valid-all.test.tsx
@@ -1,0 +1,156 @@
+import { createFormGroup, FormControl, formGroup, Validators as V } from '../../src';
+import { screen, render } from 'solid-testing-library';
+import userEvent from '@testing-library/user-event';
+import getRandomTeam, { TEAMS } from '../utils/get-random-team';
+import { For } from 'solid-js';
+
+const INIT_VALUE = '';
+const TEST_VALUE = getRandomTeam();
+
+const TRUE = String(true);
+const FALSE = String(false);
+
+const TestApp = () => {
+  const fg = createFormGroup({
+    value1: INIT_VALUE,
+    value2: [INIT_VALUE, { validators: [V.required] }],
+    value3: {
+      value31: INIT_VALUE,
+      value32: [INIT_VALUE, { validators: [V.required] }],
+    },
+  });
+  const [form, setForm] = fg.value;
+  const validAll = fg.validAll;
+
+  return (
+    <>
+      <p data-testid="valid-all">{String(validAll())}</p>
+
+      <form use:formGroup={fg}>
+        <label for="value1">value1</label>
+        <select data-testid="select-value1" name="value1" id="value1" formControlName="value1">
+          <option data-testid="value1-init" value="">
+            -- Please choose your team --
+          </option>
+          <For each={TEAMS}>
+            {(t) => (
+              <option data-testid={`value1-${t}`} value={t}>
+                {t}
+              </option>
+            )}
+          </For>
+        </select>
+
+        <label for="value2">value2</label>
+        <select data-testid="select-value2" name="value2" id="value2" formControlName="value2">
+          <option data-testid="value2-init" value="">
+            -- Please choose your team --
+          </option>
+          <For each={TEAMS}>
+            {(t) => (
+              <option data-testid={`value2-${t}`} value={t}>
+                {t}
+              </option>
+            )}
+          </For>
+        </select>
+
+        <div formGroupName="value3">
+          <label for="value31">value31</label>
+          <select data-testid="select-value31" name="value31" id="value31" formControlName="value31">
+            <option data-testid="value31-init" value="">
+              -- Please choose your team --
+            </option>
+            <For each={TEAMS}>
+              {(t) => (
+                <option data-testid={`value31-${t}`} value={t}>
+                  {t}
+                </option>
+              )}
+            </For>
+          </select>
+
+          <label for="value32">value32</label>
+          <select data-testid="select-value32" name="value32" id="value32" formControlName="value32">
+            <option data-testid="value32-init" value="">
+              -- Please choose your team --
+            </option>
+            <For each={TEAMS}>
+              {(t) => (
+                <option data-testid={`value32-${t}`} value={t}>
+                  {t}
+                </option>
+              )}
+            </For>
+          </select>
+        </div>
+      </form>
+
+      <button data-testid="btn-change-value1" onClick={() => setForm({ ...form(), value1: TEST_VALUE })}>
+        Change value1
+      </button>
+      <button data-testid="btn-change-value2" onClick={() => setForm({ ...form(), value2: TEST_VALUE })}>
+        Change value2
+      </button>
+
+      <button
+        data-testid="btn-change-value31"
+        onClick={() => setForm({ ...form(), value3: { ...form().value3, value31: TEST_VALUE } })}
+      >
+        Change value31
+      </button>
+      <button
+        data-testid="btn-change-value32"
+        onClick={() => setForm({ ...form(), value3: { ...form().value3, value32: TEST_VALUE } })}
+      >
+        Change value32
+      </button>
+    </>
+  );
+};
+
+describe('Reading and marking form controls and groups as touched or untouched', () => {
+  let $validAll: HTMLElement;
+  let $selectValue2: HTMLSelectElement;
+  let $selectValue2_productOption: HTMLOptionElement;
+  let $selectValue32: HTMLSelectElement;
+  let $selectValue32_productOption: HTMLOptionElement;
+  let $btnChangeValue1: HTMLElement;
+  let $btnChangeValue2: HTMLElement;
+  let $btnChangeValue31: HTMLElement;
+  let $btnChangeValue32: HTMLElement;
+
+  beforeEach(async () => {
+    render(() => <TestApp />);
+
+    $validAll = await screen.findByTestId('valid-all');
+    $selectValue2 = (await screen.findByTestId('select-value2')) as HTMLSelectElement;
+    $selectValue2_productOption = (await screen.findByTestId('value2-product')) as HTMLOptionElement;
+    $selectValue32 = (await screen.findByTestId('select-value32')) as HTMLSelectElement;
+    $selectValue32_productOption = (await screen.findByTestId('value32-product')) as HTMLOptionElement;
+    $btnChangeValue1 = await screen.findByTestId('btn-change-value1');
+    $btnChangeValue2 = await screen.findByTestId('btn-change-value2');
+    $btnChangeValue31 = await screen.findByTestId('btn-change-value31');
+    $btnChangeValue32 = await screen.findByTestId('btn-change-value32');
+  });
+
+  it('should mark "validAll" as "false" when at least one form control is invalid', function () {
+    expect($validAll.innerHTML).toBe(FALSE);
+  });
+
+  it('should mark form group as valid when form control values are changed to valid programmatically from outside the form', function () {
+    userEvent.click($btnChangeValue1);
+    userEvent.click($btnChangeValue2);
+    userEvent.click($btnChangeValue31);
+    userEvent.click($btnChangeValue32);
+
+    expect($validAll.innerHTML).toBe(TRUE);
+  });
+
+  it('should mark form group as valid when form control values are changed from UI to valid ones', function () {
+    userEvent.selectOptions($selectValue2, $selectValue2_productOption);
+    userEvent.selectOptions($selectValue32, $selectValue32_productOption);
+
+    expect($validAll.innerHTML).toBe(TRUE);
+  });
+});

--- a/test/select-element/form-control-validation-errors.test.tsx
+++ b/test/select-element/form-control-validation-errors.test.tsx
@@ -1,0 +1,238 @@
+import { createFormGroup, formGroup, Validators as V } from '../../src';
+import { screen, render } from 'solid-testing-library';
+import userEvent from '@testing-library/user-event';
+import { Team, TEAMS } from '../utils/get-random-team';
+import { For } from 'solid-js';
+
+const INIT_VALUE = '' as Team;
+const TEST_VALUE = TEAMS[0] as Team;
+
+const TestApp = () => {
+  const fg = createFormGroup({
+    value1: INIT_VALUE,
+    value2: [INIT_VALUE, { validators: [V.required] }],
+    value3: {
+      value31: INIT_VALUE,
+      value32: [INIT_VALUE, { validators: [V.required] }],
+    },
+  });
+  const [form, setForm] = fg.value;
+  const errors = fg.errors;
+
+  return (
+    <>
+      <p data-testid="errors-value1">{JSON.stringify(errors().value1)}</p>
+      <p data-testid="errors-value2">{JSON.stringify(errors().value2)}</p>
+      <p data-testid="errors-value31">{JSON.stringify(errors().value3.value31)}</p>
+      <p data-testid="errors-value32">{JSON.stringify(errors().value3.value32)}</p>
+
+      <form use:formGroup={fg}>
+        <label for="value1">value1</label>
+        <select data-testid="select-value1" name="value1" id="value1" formControlName="value1">
+          <For each={TEAMS}>
+            {(t) => (
+              <option data-testid={`value1-${t}`} value={t}>
+                {t}
+              </option>
+            )}
+          </For>
+        </select>
+
+        <label for="value2">value2</label>
+        <select data-testid="select-value2" name="value2" id="value2" formControlName="value2">
+          <For each={TEAMS}>
+            {(t) => (
+              <option data-testid={`value2-${t}`} value={t}>
+                {t}
+              </option>
+            )}
+          </For>
+        </select>
+
+        <div formGroupName="value3">
+          <label for="value31">value31</label>
+          <select data-testid="select-value31" name="value31" id="value31" formControlName="value31">
+            <For each={TEAMS}>
+              {(t) => (
+                <option data-testid={`value31-${t}`} value={t}>
+                  {t}
+                </option>
+              )}
+            </For>
+          </select>
+
+          <label for="value32">value32</label>
+          <select data-testid="select-value32" name="value32" id="value32" formControlName="value32">
+            <For each={TEAMS}>
+              {(t) => (
+                <option data-testid={`value32-${t}`} value={t}>
+                  {t}
+                </option>
+              )}
+            </For>
+          </select>
+        </div>
+      </form>
+
+      <button data-testid="btn-change-value1" onClick={() => setForm({ ...form(), value1: TEST_VALUE })}>
+        Change value1
+      </button>
+      <button data-testid="btn-change-value2" onClick={() => setForm({ ...form(), value2: TEST_VALUE })}>
+        Change value2
+      </button>
+
+      <button
+        data-testid="btn-change-value31"
+        onClick={() => setForm({ ...form(), value3: { ...form().value3, value31: TEST_VALUE } })}
+      >
+        Change value31
+      </button>
+      <button
+        data-testid="btn-change-value32"
+        onClick={() => setForm({ ...form(), value3: { ...form().value3, value32: TEST_VALUE } })}
+      >
+        Change value32
+      </button>
+    </>
+  );
+};
+
+describe('Reading and marking form controls and groups as touched or untouched', () => {
+  let $errorsValue1: HTMLElement;
+  let $errorsValue2: HTMLElement;
+  let $errorsValue31: HTMLElement;
+  let $errorsValue32: HTMLElement;
+  let $selectValue1: HTMLSelectElement;
+  let $selectValue1_productOption: HTMLOptionElement;
+  let $selectValue2: HTMLSelectElement;
+  let $selectValue2_productOption: HTMLOptionElement;
+  let $selectValue31: HTMLSelectElement;
+  let $selectValue31_productOption: HTMLOptionElement;
+  let $selectValue32: HTMLSelectElement;
+  let $selectValue32_productOption: HTMLOptionElement;
+  let $btnChangeValue1: HTMLElement;
+  let $btnChangeValue2: HTMLElement;
+  let $btnChangeValue31: HTMLElement;
+  let $btnChangeValue32: HTMLElement;
+
+  beforeEach(async () => {
+    render(() => <TestApp />);
+
+    $errorsValue1 = await screen.findByTestId('errors-value1');
+    $errorsValue2 = await screen.findByTestId('errors-value2');
+    $errorsValue31 = await screen.findByTestId('errors-value31');
+    $errorsValue32 = await screen.findByTestId('errors-value32');
+    $selectValue1 = (await screen.findByTestId('select-value1')) as HTMLSelectElement;
+    $selectValue1_productOption = (await screen.findByTestId('value1-product')) as HTMLOptionElement;
+    $selectValue2 = (await screen.findByTestId('select-value2')) as HTMLSelectElement;
+    $selectValue2_productOption = (await screen.findByTestId('value2-product')) as HTMLOptionElement;
+    $selectValue31 = (await screen.findByTestId('select-value31')) as HTMLSelectElement;
+    $selectValue31_productOption = (await screen.findByTestId('value31-product')) as HTMLOptionElement;
+    $selectValue32 = (await screen.findByTestId('select-value32')) as HTMLSelectElement;
+    $selectValue32_productOption = (await screen.findByTestId('value32-product')) as HTMLOptionElement;
+    $btnChangeValue1 = await screen.findByTestId('btn-change-value1');
+    $btnChangeValue2 = await screen.findByTestId('btn-change-value2');
+    $btnChangeValue31 = await screen.findByTestId('btn-change-value31');
+    $btnChangeValue32 = await screen.findByTestId('btn-change-value32');
+  });
+
+  describe('should already show validation errors on init', () => {
+    describe('for top-level controls', () => {
+      it('should show no errors when there is no validators provided in the config', () => {
+        const errors = JSON.parse($errorsValue1.innerHTML);
+
+        expect(errors).toBe(null);
+      });
+
+      it('should show errors when there is one validator that fails', () => {
+        const errors = JSON.parse($errorsValue2.innerHTML);
+
+        expect(errors).not.toBe(null);
+        expect(Object.keys(errors)).toContain('required');
+      });
+    });
+
+    describe('for nested controls', () => {
+      it('should show no errors when there is no validators provided in the config', () => {
+        const errors = JSON.parse($errorsValue31.innerHTML);
+
+        expect(errors).toBe(null);
+      });
+
+      it('should show errors when there is one validator that fails', () => {
+        const errors = JSON.parse($errorsValue32.innerHTML);
+
+        expect(errors).not.toBe(null);
+        expect(Object.keys(errors)).toContain('required');
+      });
+    });
+  });
+
+  describe('should show no errors when form control values are changed to valid programmatically from outside the form', () => {
+    describe('for top-level controls', () => {
+      it('value is changed from valid to valid', () => {
+        userEvent.click($btnChangeValue1);
+        const errors = JSON.parse($errorsValue1.innerHTML);
+
+        expect(errors).toBe(null);
+      });
+
+      it('value is changed from invalid to valid when there is one validator', () => {
+        userEvent.click($btnChangeValue2);
+        const errors = JSON.parse($errorsValue2.innerHTML);
+
+        expect(errors).toBe(null);
+      });
+    });
+
+    describe('for nested controls', () => {
+      it('value is changed from valid to valid', () => {
+        userEvent.click($btnChangeValue31);
+        const errors = JSON.parse($errorsValue31.innerHTML);
+
+        expect(errors).toBe(null);
+      });
+
+      it('value is changed from invalid to valid when there is one validator', () => {
+        userEvent.click($btnChangeValue32);
+        const errors = JSON.parse($errorsValue32.innerHTML);
+
+        expect(errors).toBe(null);
+      });
+    });
+  });
+
+  describe('should show no errors when form control values are changed to valid from UI', () => {
+    describe('for top-level controls', () => {
+      it('value is changed from valid to valid', () => {
+        userEvent.selectOptions($selectValue1, $selectValue1_productOption);
+        const errors = JSON.parse($errorsValue1.innerHTML);
+
+        expect(errors).toBe(null);
+      });
+
+      it('value is changed from invalid to valid when there is one validator', () => {
+        userEvent.selectOptions($selectValue2, $selectValue2_productOption);
+        const errors = JSON.parse($errorsValue2.innerHTML);
+
+        expect(errors).toBe(null);
+      });
+    });
+
+    describe('for nested controls', () => {
+      it('value is changed from valid to valid', () => {
+        userEvent.selectOptions($selectValue31, $selectValue31_productOption);
+        const errors = JSON.parse($errorsValue31.innerHTML);
+
+        expect(errors).toBe(null);
+      });
+
+      it('value is changed from invalid to valid when there is one validator', () => {
+        userEvent.selectOptions($selectValue32, $selectValue32_productOption);
+        const errors = JSON.parse($errorsValue32.innerHTML);
+
+        expect(errors).toBe(null);
+      });
+    });
+  });
+});

--- a/test/select-element/form-control-validators-and-valid.test.tsx
+++ b/test/select-element/form-control-validators-and-valid.test.tsx
@@ -1,0 +1,223 @@
+import { createFormGroup, formGroup, Validators as V } from '../../src';
+import { screen, render } from 'solid-testing-library';
+import userEvent from '@testing-library/user-event';
+import { Team, TEAMS } from '../utils/get-random-team';
+import { For } from 'solid-js';
+
+const INIT_VALUE = '' as Team;
+const TEST_VALUE = TEAMS[0];
+
+const TRUE = String(true);
+const FALSE = String(false);
+
+const TestApp = () => {
+  const fg = createFormGroup({
+    value1: INIT_VALUE,
+    value2: [INIT_VALUE, { validators: [V.required] }],
+    value3: {
+      value31: INIT_VALUE,
+      value32: [INIT_VALUE, { validators: [V.required] }],
+    },
+  });
+  const [form, setForm] = fg.value;
+  const valid = fg.valid;
+
+  return (
+    <>
+      <p data-testid="value1">{String(valid().value1)}</p>
+      <p data-testid="value2">{String(valid().value2)}</p>
+      <p data-testid="value31">{String(valid().value3.value31)}</p>
+      <p data-testid="value32">{String(valid().value3.value32)}</p>
+
+      <form use:formGroup={fg}>
+        <label for="value1">value1</label>
+        <select data-testid="select-value1" name="value1" id="value1" formControlName="value1">
+          <For each={TEAMS}>
+            {(t) => (
+              <option data-testid={`value1-${t}`} value={t}>
+                {t}
+              </option>
+            )}
+          </For>
+        </select>
+
+        <label for="value2">value2</label>
+        <select data-testid="select-value2" name="value2" id="value2" formControlName="value2">
+          <For each={TEAMS}>
+            {(t) => (
+              <option data-testid={`value2-${t}`} value={t}>
+                {t}
+              </option>
+            )}
+          </For>
+        </select>
+
+        <div formGroupName="value3">
+          <label for="value31">value31</label>
+          <select data-testid="select-value31" name="value31" id="value31" formControlName="value31">
+            <For each={TEAMS}>
+              {(t) => (
+                <option data-testid={`value31-${t}`} value={t}>
+                  {t}
+                </option>
+              )}
+            </For>
+          </select>
+
+          <label for="value32">value32</label>
+          <select data-testid="select-value32" name="value32" id="value32" formControlName="value32">
+            <For each={TEAMS}>
+              {(t) => (
+                <option data-testid={`value32-${t}`} value={t}>
+                  {t}
+                </option>
+              )}
+            </For>
+          </select>
+        </div>
+      </form>
+
+      <button data-testid="btn-change-value1" onClick={() => setForm({ ...form(), value1: TEST_VALUE })}>
+        Change value1
+      </button>
+      <button data-testid="btn-change-value2" onClick={() => setForm({ ...form(), value2: TEST_VALUE })}>
+        Change value2
+      </button>
+
+      <button
+        data-testid="btn-change-value31"
+        onClick={() => setForm({ ...form(), value3: { ...form().value3, value31: TEST_VALUE } })}
+      >
+        Change value31
+      </button>
+      <button
+        data-testid="btn-change-value32"
+        onClick={() => setForm({ ...form(), value3: { ...form().value3, value32: TEST_VALUE } })}
+      >
+        Change value32
+      </button>
+    </>
+  );
+};
+
+describe('Reading and marking form controls and groups as touched or untouched', () => {
+  let $value1: HTMLElement;
+  let $value2: HTMLElement;
+  let $value31: HTMLElement;
+  let $value32: HTMLElement;
+  let $selectValue1: HTMLSelectElement;
+  let $selectValue1_productOption: HTMLOptionElement;
+  let $selectValue2: HTMLSelectElement;
+  let $selectValue2_productOption: HTMLOptionElement;
+  let $selectValue31: HTMLSelectElement;
+  let $selectValue31_productOption: HTMLOptionElement;
+  let $selectValue32: HTMLSelectElement;
+  let $selectValue32_productOption: HTMLOptionElement;
+  let $btnChangeValue1: HTMLElement;
+  let $btnChangeValue2: HTMLElement;
+  let $btnChangeValue31: HTMLElement;
+  let $btnChangeValue32: HTMLElement;
+
+  beforeEach(async () => {
+    render(() => <TestApp />);
+
+    $value1 = await screen.findByTestId('value1');
+    $value2 = await screen.findByTestId('value2');
+    $value31 = await screen.findByTestId('value31');
+    $value32 = await screen.findByTestId('value32');
+    $selectValue1 = (await screen.findByTestId('select-value1')) as HTMLSelectElement;
+    $selectValue1_productOption = (await screen.findByTestId('value1-product')) as HTMLOptionElement;
+    $selectValue2 = (await screen.findByTestId('select-value2')) as HTMLSelectElement;
+    $selectValue2_productOption = (await screen.findByTestId('value2-product')) as HTMLOptionElement;
+    $selectValue31 = (await screen.findByTestId('select-value31')) as HTMLSelectElement;
+    $selectValue31_productOption = (await screen.findByTestId('value31-product')) as HTMLOptionElement;
+    $selectValue32 = (await screen.findByTestId('select-value32')) as HTMLSelectElement;
+    $selectValue32_productOption = (await screen.findByTestId('value32-product')) as HTMLOptionElement;
+    $btnChangeValue1 = await screen.findByTestId('btn-change-value1');
+    $btnChangeValue2 = await screen.findByTestId('btn-change-value2');
+    $btnChangeValue31 = await screen.findByTestId('btn-change-value31');
+    $btnChangeValue32 = await screen.findByTestId('btn-change-value32');
+  });
+
+  describe('should already mark form controls as valid/invalid on init', () => {
+    describe('for top-level controls', () => {
+      it('should mark form control as valid when there is no validators provided in the config', () => {
+        expect($value1.innerHTML).toBe(TRUE);
+      });
+
+      it('should mark form control as invalid when there is one validator that fails', () => {
+        expect($value2.innerHTML).toBe(FALSE);
+      });
+    });
+
+    describe('for nested controls', () => {
+      it('should mark form control as valid when there is no validators provided in the config', () => {
+        expect($value31.innerHTML).toBe(TRUE);
+      });
+
+      it('should mark form control as invalid when there is one validator that fails', () => {
+        expect($value32.innerHTML).toBe(FALSE);
+      });
+    });
+  });
+
+  describe('should mark form controls as valid when form control values are changed to valid programmatically from outside the form', () => {
+    describe('for top-level controls', () => {
+      it('value is changed from valid to valid', () => {
+        userEvent.click($btnChangeValue1);
+
+        expect($value1.innerHTML).toBe(TRUE);
+      });
+
+      it('value is changed from invalid to valid when there is one validator', () => {
+        userEvent.click($btnChangeValue2);
+
+        expect($value2.innerHTML).toBe(TRUE);
+      });
+    });
+
+    describe('for nested controls', () => {
+      it('value is changed from valid to valid', () => {
+        userEvent.click($btnChangeValue31);
+
+        expect($value31.innerHTML).toBe(TRUE);
+      });
+
+      it('value is changed from invalid to valid when there is one validator', () => {
+        userEvent.click($btnChangeValue32);
+
+        expect($value32.innerHTML).toBe(TRUE);
+      });
+    });
+  });
+
+  describe('should mark form controls as valid when form control values are changed from UI', () => {
+    describe('for top-level controls', () => {
+      it('value is changed from valid to valid', () => {
+        userEvent.selectOptions($selectValue1, $selectValue1_productOption);
+
+        expect($value1.innerHTML).toBe(TRUE);
+      });
+
+      it('value is changed from invalid to valid when there is one validator', () => {
+        userEvent.selectOptions($selectValue2, $selectValue2_productOption);
+
+        expect($value2.innerHTML).toBe(TRUE);
+      });
+    });
+
+    describe('for nested controls', () => {
+      it('value is changed from valid to valid', () => {
+        userEvent.selectOptions($selectValue31, $selectValue31_productOption);
+
+        expect($value31.innerHTML).toBe(TRUE);
+      });
+
+      it('value is changed from invalid to valid when there is one validator', () => {
+        userEvent.selectOptions($selectValue32, $selectValue32_productOption);
+
+        expect($value32.innerHTML).toBe(TRUE);
+      });
+    });
+  });
+});

--- a/test/select-element/form-control-value.test.tsx
+++ b/test/select-element/form-control-value.test.tsx
@@ -1,0 +1,85 @@
+import { createFormGroup, formGroup } from '../../src';
+import { screen, render } from 'solid-testing-library';
+import userEvent from '@testing-library/user-event';
+import getRandomTeam, { Team, TEAMS } from '../utils/get-random-team';
+import { For } from 'solid-js';
+
+const INIT_INPUT_VALUE = TEAMS[0] as Team | null;
+const NULL = String(null);
+
+let randomTeam = getRandomTeam();
+
+const TestApp = () => {
+  const fg = createFormGroup({
+    team: INIT_INPUT_VALUE,
+  });
+  const [form, setForm] = fg.value;
+
+  return (
+    <>
+      <p data-testid="value">{form().team}</p>
+
+      <form use:formGroup={fg}>
+        <select data-testid="select-value" name="value" id="value" formControlName="team">
+          <For each={TEAMS}>
+            {(t) => (
+              <option data-testid={`value-${t}`} value={t}>
+                {t}
+              </option>
+            )}
+          </For>
+        </select>
+      </form>
+
+      <button data-testid="btn" onClick={() => setForm({ team: randomTeam })}>
+        Update
+      </button>
+      <button data-testid="btn-null" onClick={() => setForm({ team: null })}>
+        Update to null
+      </button>
+    </>
+  );
+};
+
+describe('Input element with type="radio" as form control', () => {
+  let $value: HTMLElement;
+  let $changeToStringButton: HTMLElement;
+  let $changeToNullButton: HTMLElement;
+  let $selectValue: HTMLSelectElement;
+  let $selectValue_productOption: HTMLOptionElement;
+
+  beforeEach(async () => {
+    render(() => <TestApp />);
+    randomTeam = getRandomTeam();
+
+    $value = await screen.findByTestId('value');
+    $changeToStringButton = await screen.findByTestId('btn');
+    $changeToNullButton = await screen.findByTestId('btn-null');
+    $selectValue = (await screen.findByTestId('select-value')) as HTMLSelectElement;
+    $selectValue_productOption = (await screen.findByTestId('value-product')) as HTMLOptionElement;
+  });
+
+  it('should init value with the one provided in createFormGroup', async () => {
+    expect($value.innerHTML).toBe(INIT_INPUT_VALUE);
+  });
+
+  describe('should update form value when updating programmatically from outside the form', () => {
+    it('with string', async () => {
+      userEvent.click($changeToStringButton);
+
+      expect($value.innerHTML).toBe(randomTeam);
+    });
+
+    it('with null', () => {
+      userEvent.click($changeToNullButton);
+
+      expect($value.innerHTML === NULL || $value.innerHTML === '').toBeTruthy();
+    });
+  });
+
+  it('should update form value when on manual input', async () => {
+    userEvent.selectOptions($selectValue, $selectValue_productOption);
+
+    expect($value.innerHTML).toBe('product');
+  });
+});

--- a/test/select-element/form-group-nested.test.tsx
+++ b/test/select-element/form-group-nested.test.tsx
@@ -1,0 +1,145 @@
+import { createFormGroup, formGroup } from '../../src';
+import { screen, render } from 'solid-testing-library';
+import userEvent from '@testing-library/user-event';
+import { Team, TEAMS } from '../utils/get-random-team';
+import { For } from 'solid-js';
+
+const INIT_INPUT_VALUE = TEAMS[0] as Team;
+const TEST_INPUT_VALUE = TEAMS[1] as Team;
+const INIT_INPUT_NESTED_VALUE = TEAMS[1] as Team;
+const TEST_INPUT_NESTED_VALUE = TEAMS[2] as Team;
+
+const TestApp = () => {
+  const fg = createFormGroup({
+    value: {
+      nested1: INIT_INPUT_VALUE,
+      nested2: {
+        nested21: INIT_INPUT_NESTED_VALUE,
+      },
+    },
+  });
+  const [form, setForm] = fg.value;
+
+  return (
+    <>
+      <p data-testid="value-nested1">{form().value.nested1}</p>
+      <p data-testid="value-nested21">{form().value.nested2.nested21}</p>
+
+      <form use:formGroup={fg}>
+        <div formGroupName="value">
+          <label for="nested1">nested1</label>
+          <select data-testid="select-nested1" name="nested1" id="nested1" formControlName="nested1">
+            <For each={TEAMS}>
+              {(t) => (
+                <option data-testid={`nested1-${t}`} value={t}>
+                  {t}
+                </option>
+              )}
+            </For>
+          </select>
+
+          <span formGroupName="nested2">
+            <label for="nested21">nested21</label>
+            <select data-testid="select-nested21" name="nested21" id="nested21" formControlName="nested21">
+              <For each={TEAMS}>
+                {(t) => (
+                  <option data-testid={`nested21-${t}`} value={t}>
+                    {t}
+                  </option>
+                )}
+              </For>
+            </select>
+          </span>
+        </div>
+      </form>
+
+      <button
+        data-testid="btn-nested1"
+        onClick={() => setForm({ ...form(), value: { ...form().value, nested1: TEST_INPUT_VALUE } })}
+      >
+        Change nested1
+      </button>
+      <button
+        data-testid="btn-nested21"
+        onClick={() =>
+          setForm({
+            ...form(),
+            value: {
+              ...form().value,
+              nested2: { ...form().value.nested2, nested21: TEST_INPUT_NESTED_VALUE },
+            },
+          })
+        }
+      >
+        Change nested21
+      </button>
+    </>
+  );
+};
+
+describe('Nested form control', () => {
+  let $valueNested1: HTMLElement;
+  let $valueNested21: HTMLElement;
+  let $selectNested1: HTMLSelectElement;
+  let $selectNested1_productOption: HTMLOptionElement;
+  let $selectNested21: HTMLSelectElement;
+  let $selectNested21_testingOption: HTMLOptionElement;
+  let $btnNested1: HTMLElement;
+  let $btnNested21: HTMLElement;
+
+  beforeEach(async () => {
+    render(() => <TestApp />);
+
+    $valueNested1 = await screen.findByTestId('value-nested1');
+    $valueNested21 = await screen.findByTestId('value-nested21');
+    $selectNested1 = (await screen.findByTestId('select-nested1')) as HTMLSelectElement;
+    $selectNested1_productOption = (await screen.findByTestId('nested1-product')) as HTMLOptionElement;
+    $selectNested21 = (await screen.findByTestId('select-nested21')) as HTMLSelectElement;
+    $selectNested21_testingOption = (await screen.findByTestId('nested21-testing')) as HTMLOptionElement;
+    $btnNested1 = await screen.findByTestId('btn-nested1');
+    $btnNested21 = await screen.findByTestId('btn-nested21');
+  });
+
+  describe('should init value with the one provided in createFormGroup', () => {
+    it('for value nested on lvl 1', () => {
+      expect($valueNested1.innerHTML).toBe(INIT_INPUT_VALUE);
+      expect($selectNested1.value).toBe(INIT_INPUT_VALUE);
+    });
+
+    it('for value nested on lvl 2', () => {
+      expect($valueNested21.innerHTML).toBe(String(INIT_INPUT_NESTED_VALUE));
+      // TODO this fails, although it works when tested manually
+      // expect($selectNested21.value).toBe(String(INIT_INPUT_NESTED_VALUE));
+    });
+  });
+
+  describe('should update form value when updating programmatically from outside the form', () => {
+    it('for value nested on lvl 1', () => {
+      userEvent.click($btnNested1);
+
+      expect($valueNested1.innerHTML).toBe(TEST_INPUT_VALUE);
+      expect($selectNested1.value).toBe(TEST_INPUT_VALUE);
+    });
+
+    it('for value nested on lvl 2', () => {
+      userEvent.click($btnNested21);
+
+      expect($valueNested21.innerHTML).toBe(String(TEST_INPUT_NESTED_VALUE));
+      expect($selectNested21.value).toBe(String(TEST_INPUT_NESTED_VALUE));
+    });
+  });
+
+  describe('should update form value when on manual input', () => {
+    it('for value nested on lvl 1', () => {
+      userEvent.selectOptions($selectNested1, $selectNested1_productOption);
+
+      expect($valueNested1.innerHTML).toBe(TEST_INPUT_VALUE);
+    });
+
+    it('for value nested on lvl 2', () => {
+      userEvent.selectOptions($selectNested21, $selectNested21_testingOption);
+
+      expect($valueNested21.innerHTML).toBe(String(TEST_INPUT_NESTED_VALUE));
+    });
+  });
+});

--- a/test/utils/get-random-team.ts
+++ b/test/utils/get-random-team.ts
@@ -1,4 +1,7 @@
-export default function getRandomTeam(): 'engineering' | 'product' | 'testing' {
-  const validTeams = ['engineering', 'product', 'testing'] as const;
-  return validTeams[Math.floor(Math.random() * 3)];
+export const TEAMS = ['engineering', 'product', 'testing'] as const;
+
+export type Team = typeof TEAMS[number];
+
+export default function getRandomTeam(): Team {
+  return TEAMS[Math.floor(Math.random() * TEAMS.length)];
 }


### PR DESCRIPTION
Added support for `<select>` element: 
- updated `formGroup` directive to support `<select>` element
  + Support null as an empty value for all form control
  + Support `select` elements inside label elements
  + Support nested form groups
  + Support `disabled`, `touched` and `dirty` form control properties for `select` element
  + Support `disabledAll`, `touchedAll` and `dirtyAll` form group properties that include `select` element
  + Support adding validators to `select` element
  + Support `valid` and `validAll` for `select` element
  + Added errors form control property for accessing validation errors for `select` element
- added tests for all above cases
- updated docs