### PR TITLE
Support `textarea` element

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ yarn add solar-forms
     + [Type of "checkbox"](#type-of-checkbox)
     + [Type of "radio"](#type-of-radio)
   * [Binding form controls to `<select>` element](#binding-form-controls-to-select-element)
+  * [Binding form controls to `<textarea>` element](#binding-form-controls-to-textarea-element)
   * [Form control errors](#form-control-errors)
     + [Form control name does not match any key from form group](#form-control-name-does-not-match-any-key-from-form-group)
     + [Form control type does not match the type of an input element](#form-control-type-does-not-match-the-type-of-an-input-element)
@@ -1553,7 +1554,7 @@ type CountryOption = '' | 'Poland' | 'Spain' | 'Germany';
 
 // Component definition
 
-const fg = createFormGroup<CustomFormGroup>({
+const fg = createFormGroup({
   // 1️⃣ Default value is set here
   country: '' as CountryOption,
 });
@@ -1571,6 +1572,28 @@ return (
         <option value="Germany">Germany</option>
       </select>
     </label>
+  </form>
+);
+```
+
+### Binding form controls to `<textarea>` element
+
+`textarea` element is a string-based form control. You can
+define your form control's default value as `string` or `null`:
+
+```tsx
+// Component definition
+
+const fg = createFormGroup({
+  // 1️⃣ Default value is set here
+  bio: '',
+});
+
+return (
+  <form use:formGroup={fg}>
+    <label htmlFor="bio">Bio</label>
+    {/* 2️⃣ Here we bind form control to form group */}
+    <textarea name="bio" id="bio" formControlName="bio" />
   </form>
 );
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solar-forms",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Form library for SolidJS inspired by Angular's reactive forms",
   "info": "Solar Forms allows you to create reactive and type-safe state for your form controls. It lets you take over form controls and access key information like control's current value, whether it's disabled, valid, etc. as SolidJS signals. Form controls can also be pre-configured with validator functions, ensuring your form won't be marked as valid unless all data is correct.",
   "type": "module",

--- a/src/core/form-group-directive/utils/get-form-control.ts
+++ b/src/core/form-group-directive/utils/get-form-control.ts
@@ -12,28 +12,28 @@ function isSelect(child: JSX.Element): child is HTMLSelectElement {
   return child instanceof HTMLSelectElement;
 }
 
+function isTextArea(child: JSX.Element): child is HTMLTextAreaElement {
+  return child instanceof HTMLTextAreaElement;
+}
+
 function getAssociatedControlForLabel(label: HTMLLabelElement) {
   return Array.from(label.children).find((c) => c.id === label.htmlFor);
 }
 
 /**
  * Extracts form control from the HTML element. Identifies:
- * - standalone `input` elements
- * - `label`s with `input`s as children bound by `htmlFor` attribute.
+ * - standalone `input`, `select` and `textarea` elements
+ * - `label`s with form elements as children bound by `htmlFor`/`for` attribute.
  */
-export function getFormControl(child: JSX.Element): HTMLInputElement | HTMLSelectElement | null {
-  if (isInput(child)) {
-    return child;
-  }
-  if (isSelect(child)) {
+export function getFormControl(
+  child: JSX.Element
+): HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement | null {
+  if (isInput(child) || isSelect(child) || isTextArea(child)) {
     return child;
   }
   if (isLabel(child)) {
     const control = getAssociatedControlForLabel(child);
-    if (isInput(control)) {
-      return control;
-    }
-    if (isSelect(control)) {
+    if (isInput(control) || isSelect(control) || isTextArea(control)) {
       return control;
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,10 @@ declare module 'solid-js' {
       formControlName?: string;
     }
 
+    interface TextareaHTMLAttributes<T> {
+      formControlName?: string;
+    }
+
     interface HTMLAttributes<T> {
       formGroupName?: string;
     }

--- a/test/textarea-element/form-control-dirty-all.test.tsx
+++ b/test/textarea-element/form-control-dirty-all.test.tsx
@@ -1,0 +1,103 @@
+import { createFormGroup, formGroup } from '../../src';
+import { screen, render } from 'solid-testing-library';
+import userEvent from '@testing-library/user-event';
+import getRandomString from '../utils/get-random-string';
+
+const INIT_VALUE = getRandomString();
+const TEST_VALUE = getRandomString();
+
+const TestApp = () => {
+  const fg = createFormGroup({
+    value1: INIT_VALUE,
+    value2: {
+      value21: INIT_VALUE,
+    },
+  });
+  const [dirty, setDirty] = fg.dirty;
+  const [dirtyAll, setDirtyAll] = fg.dirtyAll;
+
+  return (
+    <>
+      <p data-testid="value-dirtyAll">{JSON.stringify(dirtyAll())}</p>
+
+      <form use:formGroup={fg}>
+        <label for="value1">value1</label>
+        <textarea data-testid="input-value1" name="value1" id="value1" formControlName="value1" />
+
+        <div formGroupName="value2">
+          <label for="value21">value21</label>
+          <textarea data-testid="input-value21" name="value21" id="value21" formControlName="value21" />
+        </div>
+      </form>
+
+      <button data-testid="btn-mark-all-dirty" onClick={() => setDirtyAll(true)}>
+        Mark all as dirty
+      </button>
+      <button data-testid="btn-mark-all-pristine" onClick={() => setDirtyAll(false)}>
+        Mark all as pristine
+      </button>
+      <button
+        data-testid="btn-mark-each-dirty"
+        onClick={() => setDirty({ ...dirty(), value1: true, value2: { value21: true } })}
+      >
+        Mark each as dirty
+      </button>
+    </>
+  );
+};
+
+describe('Marking all form controls and groups as dirty or pristine for `textarea` element', () => {
+  let $valueDirtyAll: HTMLElement;
+  let $inputValue1: HTMLTextAreaElement;
+  let $inputValue21: HTMLTextAreaElement;
+  let $btnMarkAllDirty: HTMLElement;
+  let $btnMarkAllPristine: HTMLElement;
+  let $btnMarkEachDirty: HTMLElement;
+
+  beforeEach(async () => {
+    render(() => <TestApp />);
+
+    $valueDirtyAll = await screen.findByTestId('value-dirtyAll');
+    $inputValue1 = (await screen.findByTestId('input-value1')) as HTMLTextAreaElement;
+    $inputValue21 = (await screen.findByTestId('input-value21')) as HTMLTextAreaElement;
+    $btnMarkAllDirty = await screen.findByTestId('btn-mark-all-dirty');
+    $btnMarkAllPristine = await screen.findByTestId('btn-mark-all-pristine');
+    $btnMarkEachDirty = await screen.findByTestId('btn-mark-each-dirty');
+  });
+
+  it('should read dirtyAll value as "false" initially', () => {
+    expect($valueDirtyAll.innerHTML).toBe(String(false));
+  });
+
+  it('should read dirtyAll value as "false" when not all form controls are dirty', () => {
+    userEvent.type($inputValue1, TEST_VALUE);
+
+    expect($valueDirtyAll.innerHTML).toBe(String(false));
+  });
+
+  it('should read dirtyAll value as "true" when all controls were changed from UI', () => {
+    userEvent.type($inputValue1, TEST_VALUE);
+    userEvent.type($inputValue21, TEST_VALUE);
+
+    expect($valueDirtyAll.innerHTML).toBe(String(true));
+  });
+
+  it('should read dirtyAll value as "true" when all controls were marked as dirty programmatically from outside the form', () => {
+    userEvent.click($btnMarkEachDirty);
+
+    expect($valueDirtyAll.innerHTML).toBe(String(true));
+  });
+
+  it('should disable all form controls when setting the property programmatically from outside the form', () => {
+    userEvent.click($btnMarkAllDirty);
+
+    expect($valueDirtyAll.innerHTML).toBe(String(true));
+  });
+
+  it('should read dirtyAll value as "false" when setting the touched property to "false" programmatically from outside the form', () => {
+    userEvent.click($btnMarkAllDirty);
+    userEvent.click($btnMarkAllPristine);
+
+    expect($valueDirtyAll.innerHTML).toBe(String(false));
+  });
+});

--- a/test/textarea-element/form-control-dirty.test.tsx
+++ b/test/textarea-element/form-control-dirty.test.tsx
@@ -1,0 +1,133 @@
+import { createFormGroup, formGroup } from '../../src';
+import { screen, render } from 'solid-testing-library';
+import userEvent from '@testing-library/user-event';
+import getRandomString from '../utils/get-random-string';
+
+const INIT_VALUE = getRandomString();
+const TEST_VALUE = getRandomString();
+
+const TestApp = () => {
+  const fg = createFormGroup({
+    value1: INIT_VALUE,
+    value2: {
+      value21: INIT_VALUE,
+    },
+  });
+  const [form, setForm] = fg.value;
+  const [dirty, setDirty] = fg.dirty;
+
+  return (
+    <>
+      <p data-testid="dirty1">{String(dirty().value1)}</p>
+      <p data-testid="dirty21">{String(dirty().value2.value21)}</p>
+
+      <form use:formGroup={fg}>
+        <label for="value1">value1</label>
+        <textarea data-testid="input-value1" name="value1" id="value1" formControlName="value1" />
+
+        <div formGroupName="value2">
+          <label for="value21">value21</label>
+          <textarea data-testid="input-value21" name="value21" id="value21" formControlName="value21" />
+        </div>
+      </form>
+
+      <button data-testid="btn-change-value1" onClick={() => setForm({ ...form(), value1: TEST_VALUE })}>
+        Change value1
+      </button>
+
+      <button
+        data-testid="btn-change-value21"
+        onClick={() => setForm({ ...form(), value2: { value21: TEST_VALUE } })}
+      >
+        Change value21
+      </button>
+
+      <button data-testid="btn-mark-dirty-value1" onClick={() => setDirty({ ...dirty(), value1: true })}>
+        Mark value1 dirty
+      </button>
+
+      <button
+        data-testid="btn-mark-dirty-value21"
+        onClick={() => setDirty({ ...dirty(), value2: { value21: true } })}
+      >
+        Mark value21 dirty
+      </button>
+    </>
+  );
+};
+
+describe('Reading and marking form controls and groups as dirty for `textarea` element', () => {
+  let $dirty1: HTMLElement;
+  let $dirty21: HTMLElement;
+  let $inputValue1: HTMLTextAreaElement;
+  let $inputValue21: HTMLTextAreaElement;
+  let $btnValue1: HTMLElement;
+  let $btnValue21: HTMLElement;
+  let $btnMarkDirtyValue1: HTMLElement;
+  let $btnMarkDirtyValue21: HTMLElement;
+
+  beforeEach(async () => {
+    render(() => <TestApp />);
+
+    $dirty1 = await screen.findByTestId('dirty1');
+    $dirty21 = await screen.findByTestId('dirty21');
+    $inputValue1 = (await screen.findByTestId('input-value1')) as HTMLTextAreaElement;
+    $inputValue21 = (await screen.findByTestId('input-value21')) as HTMLTextAreaElement;
+    $btnValue1 = await screen.findByTestId('btn-change-value1');
+    $btnValue21 = await screen.findByTestId('btn-change-value21');
+    $btnMarkDirtyValue1 = await screen.findByTestId('btn-mark-dirty-value1');
+    $btnMarkDirtyValue21 = await screen.findByTestId('btn-mark-dirty-value21');
+  });
+
+  describe('should set control as pristine (not dirty) when initialized', () => {
+    it('for top-level control', () => {
+      expect($dirty1.innerHTML).toBe(String(false));
+    });
+
+    it('for nested control', () => {
+      expect($dirty21.innerHTML).toBe(String(false));
+    });
+  });
+
+  describe('should change control to dirty when input value is changed from UI', () => {
+    it('for top-level control', () => {
+      userEvent.type($inputValue1, TEST_VALUE);
+
+      expect($dirty1.innerHTML).toBe(String(true));
+    });
+
+    it('for nested control', () => {
+      userEvent.type($inputValue21, TEST_VALUE);
+
+      expect($dirty21.innerHTML).toBe(String(true));
+    });
+  });
+
+  describe('should NOT change control to dirty when input value is changed programmatically from outside the form', () => {
+    it('for top-level control', () => {
+      userEvent.click($btnValue1);
+
+      expect($dirty1.innerHTML).toBe(String(false));
+    });
+
+    it('for nested control', () => {
+      userEvent.click($btnValue21);
+
+      expect($dirty21.innerHTML).toBe(String(false));
+    });
+  });
+
+  describe('should change control to dirty when changed programmatically from outside the form', () => {
+    it('for top-level control', () => {
+      userEvent.click($btnMarkDirtyValue1);
+
+      expect($dirty1.innerHTML).toBe(String(true));
+    });
+
+    it('for nested control', () => {
+      userEvent.click($btnMarkDirtyValue21);
+
+      expect($dirty21.innerHTML).toBe(String(true));
+    });
+  });
+});

--- a/test/textarea-element/form-control-disabled-all.test.tsx
+++ b/test/textarea-element/form-control-disabled-all.test.tsx
@@ -1,0 +1,116 @@
+import { createFormGroup, formGroup } from '../../src';
+import { screen, render } from 'solid-testing-library';
+import userEvent from '@testing-library/user-event';
+
+const TestApp = () => {
+  const fg = createFormGroup({
+    controlEnabled: ['test', { disabled: false }],
+    controlDisabled: ['test', { disabled: true }],
+    nested: {
+      controlEnabled: ['test', { disabled: false }],
+      controlDisabled: ['test', { disabled: true }],
+    },
+  });
+  const [disabledAll, setDisabledAll] = fg.disabledAll;
+
+  return (
+    <>
+      <p data-testid="value-disabledAll">{JSON.stringify(disabledAll())}</p>
+
+      <form use:formGroup={fg}>
+        <label for="controlEnabled">controlEnabled</label>
+        <textarea
+          data-testid="input-controlEnabled"
+          name="controlEnabled"
+          id="controlEnabled"
+          formControlName="controlEnabled"
+        />
+
+        <label for="controlDisabled">controlDisabled</label>
+        <textarea
+          data-testid="input-controlDisabled"
+          name="controlDisabled"
+          id="controlDisabled"
+          formControlName="controlDisabled"
+        />
+
+        <div formGroupName="nested">
+          <label for="controlEnabled">controlEnabled</label>
+          <textarea
+            data-testid="input-nested-controlEnabled"
+            name="controlEnabled"
+            id="controlEnabled"
+            formControlName="controlEnabled"
+          />
+
+          <label for="controlDisabled">controlDisabled</label>
+          <textarea
+            data-testid="input-nested-controlDisabled"
+            name="controlDisabled"
+            id="controlDisabled"
+            formControlName="controlDisabled"
+          />
+        </div>
+      </form>
+
+      <button data-testid="btn-disable-all" onClick={() => setDisabledAll(true)}>
+        Disable all
+      </button>
+      <button data-testid="btn-enable-all" onClick={() => setDisabledAll(false)}>
+        Enable all
+      </button>
+    </>
+  );
+};
+
+describe('Disabling and enabling all form controls and groups for `textarea` element', () => {
+  let $controlEnabled: HTMLTextAreaElement;
+  let $controlDisabled: HTMLTextAreaElement;
+  let $nestedControlEnabled: HTMLTextAreaElement;
+  let $nestedControlDisabled: HTMLTextAreaElement;
+  let $btnDisableAll: HTMLElement;
+  let $btnEnableAll: HTMLElement;
+  let $valueDisabledAll: HTMLElement;
+
+  const expectAllControlsToBe = (value: 'enabled' | 'disabled') => {
+    const disabled = value === 'disabled';
+
+    if (disabled) {
+      expect($valueDisabledAll.innerHTML).toBe(String(disabled));
+    }
+    expect($controlEnabled.disabled).toBe(disabled);
+    expect($controlDisabled.disabled).toBe(disabled);
+    expect($nestedControlDisabled.disabled).toBe(disabled);
+    expect($nestedControlEnabled.disabled).toBe(disabled);
+  };
+
+  beforeEach(async () => {
+    render(() => <TestApp />);
+
+    $controlEnabled = (await screen.findByTestId('input-controlEnabled')) as HTMLTextAreaElement;
+    $controlDisabled = (await screen.findByTestId('input-controlDisabled')) as HTMLTextAreaElement;
+    $nestedControlEnabled = (await screen.findByTestId('input-nested-controlEnabled')) as HTMLTextAreaElement;
+    $nestedControlDisabled = (await screen.findByTestId(
+      'input-nested-controlDisabled'
+    )) as HTMLTextAreaElement;
+    $btnDisableAll = await screen.findByTestId('btn-disable-all');
+    $btnEnableAll = await screen.findByTestId('btn-enable-all');
+    $valueDisabledAll = await screen.findByTestId('value-disabledAll');
+  });
+
+  it('should read disabledAll value as "false" when at least one form control is enabled', () => {
+    expect($valueDisabledAll.innerHTML).toBe(String(false));
+  });
+
+  it('should disable all form controls when setting the property programmatically from outside the form', () => {
+    userEvent.click($btnDisableAll);
+
+    expectAllControlsToBe('disabled');
+  });
+
+  it('should enable all form controls when setting the property programmatically from outside the form', () => {
+    userEvent.click($btnEnableAll);
+
+    expectAllControlsToBe('enabled');
+  });
+});

--- a/test/textarea-element/form-control-disabled.test.tsx
+++ b/test/textarea-element/form-control-disabled.test.tsx
@@ -1,0 +1,197 @@
+import { createFormGroup, formGroup } from '../../src';
+import { screen, render } from 'solid-testing-library';
+import userEvent from '@testing-library/user-event';
+
+const TestApp = () => {
+  const fg = createFormGroup({
+    controlEnabled1: 'test',
+    controlEnabled2: ['test', { disabled: false }],
+    controlDisabled: ['test', { disabled: true }],
+    nested: {
+      controlEnabled1: 'test',
+      controlEnabled2: ['test', { disabled: false }],
+      controlDisabled: ['test', { disabled: true }],
+    },
+  });
+  const [disabled, setDisabled] = fg.disabled;
+
+  return (
+    <>
+      <form use:formGroup={fg}>
+        <label for="controlEnabled1">controlEnabled1</label>
+        <textarea
+          data-testid="input-controlEnabled1"
+          name="controlEnabled1"
+          id="controlEnabled1"
+          formControlName="controlEnabled1"
+        />
+
+        <label for="controlEnabled2">controlEnabled2</label>
+        <textarea
+          data-testid="input-controlEnabled2"
+          name="controlEnabled2"
+          id="controlEnabled2"
+          formControlName="controlEnabled2"
+        />
+
+        <label for="controlDisabled">controlDisabled</label>
+        <textarea
+          data-testid="input-controlDisabled"
+          name="controlDisabled"
+          id="controlDisabled"
+          formControlName="controlDisabled"
+        />
+
+        <div formGroupName="nested">
+          <label for="controlEnabled1">controlEnabled1</label>
+          <textarea
+            data-testid="input-nested-controlEnabled1"
+            name="nested-controlEnabled1"
+            id="nested-controlEnabled1"
+            formControlName="controlEnabled1"
+          />
+
+          <label for="controlEnabled2">controlEnabled2</label>
+          <textarea
+            data-testid="input-nested-controlEnabled2"
+            name="nested-controlEnabled2"
+            id="nested-controlEnabled2"
+            formControlName="controlEnabled2"
+          />
+
+          <label for="controlDisabled">controlDisabled</label>
+          <textarea
+            data-testid="input-nested-controlDisabled"
+            name="controlDisabled"
+            id="controlDisabled"
+            formControlName="controlDisabled"
+          />
+        </div>
+      </form>
+
+      <button
+        data-testid="btn-controlEnabled1"
+        onClick={() => setDisabled({ ...disabled(), controlEnabled1: true })}
+      >
+        Change controlEnabled1
+      </button>
+
+      <button
+        data-testid="btn-controlEnabled2"
+        onClick={() => setDisabled({ ...disabled(), controlEnabled2: true })}
+      >
+        Change controlEnabled2
+      </button>
+
+      <button
+        data-testid="btn-nested-controlEnabled1"
+        onClick={() =>
+          setDisabled({ ...disabled(), nested: { ...disabled().nested, controlEnabled1: true } })
+        }
+      >
+        Change nested controlEnabled1
+      </button>
+
+      <button
+        data-testid="btn-nested-controlEnabled2"
+        onClick={() =>
+          setDisabled({ ...disabled(), nested: { ...disabled().nested, controlEnabled2: true } })
+        }
+      >
+        Change nested controlEnabled2
+      </button>
+    </>
+  );
+};
+
+describe('Disabling form controls and groups for `textarea` element', () => {
+  let $controlEnabled1: HTMLTextAreaElement;
+  let $controlEnabled2: HTMLTextAreaElement;
+  let $controlDisabled: HTMLTextAreaElement;
+  let $nestedControlEnabled1: HTMLTextAreaElement;
+  let $nestedControlEnabled2: HTMLTextAreaElement;
+  let $nestedControlDisabled: HTMLTextAreaElement;
+  let $btnControlEnabled1: HTMLElement;
+  let $btnControlEnabled2: HTMLElement;
+  let $btnNestedControlEnabled1: HTMLElement;
+  let $btnNestedControlEnabled2: HTMLElement;
+
+  beforeEach(async () => {
+    render(() => <TestApp />);
+
+    $controlEnabled1 = (await screen.findByTestId('input-controlEnabled1')) as HTMLTextAreaElement;
+    $controlEnabled2 = (await screen.findByTestId('input-controlEnabled2')) as HTMLTextAreaElement;
+    $controlDisabled = (await screen.findByTestId('input-controlDisabled')) as HTMLTextAreaElement;
+    $nestedControlEnabled1 = (await screen.findByTestId(
+      'input-nested-controlEnabled1'
+    )) as HTMLTextAreaElement;
+    $nestedControlEnabled2 = (await screen.findByTestId(
+      'input-nested-controlEnabled2'
+    )) as HTMLTextAreaElement;
+    $nestedControlDisabled = (await screen.findByTestId(
+      'input-nested-controlDisabled'
+    )) as HTMLTextAreaElement;
+    $btnControlEnabled1 = await screen.findByTestId('btn-controlEnabled1');
+    $btnControlEnabled2 = await screen.findByTestId('btn-controlEnabled2');
+    $btnNestedControlEnabled1 = await screen.findByTestId('btn-nested-controlEnabled1');
+    $btnNestedControlEnabled2 = await screen.findByTestId('btn-nested-controlEnabled2');
+  });
+
+  describe('should set control to disabled when initialized as one', () => {
+    it('for top-level control', () => {
+      expect($controlDisabled.disabled).toBe(true);
+    });
+
+    it('for nested control', () => {
+      expect($nestedControlDisabled.disabled).toBe(true);
+    });
+  });
+
+  describe('should set control to enabled when initialized as one', () => {
+    describe('for top-level control', () => {
+      it('without config object', () => {
+        expect($controlEnabled1.disabled).toBe(false);
+      });
+
+      it('with config object', () => {
+        expect($controlEnabled2.disabled).toBe(false);
+      });
+    });
+
+    describe('for nested control', () => {
+      it('without config object', () => {
+        expect($nestedControlEnabled1.disabled).toBe(false);
+      });
+
+      it('with config object', () => {
+        expect($nestedControlEnabled2.disabled).toBe(false);
+      });
+    });
+  });
+
+  describe('should set control to disabled when programmatically set from outside the form', () => {
+    describe('for top-level control', () => {
+      it('without config object', () => {
+        userEvent.click($btnControlEnabled1);
+        expect($controlEnabled1.disabled).toBe(true);
+      });
+
+      it('with config object', () => {
+        userEvent.click($btnControlEnabled2);
+        expect($controlEnabled2.disabled).toBe(true);
+      });
+    });
+
+    describe('for nested control', () => {
+      it('without config object', () => {
+        userEvent.click($btnNestedControlEnabled1);
+        expect($nestedControlEnabled1.disabled).toBe(true);
+      });
+
+      it('with config object', () => {
+        userEvent.click($btnNestedControlEnabled2);
+        expect($nestedControlEnabled2.disabled).toBe(true);
+      });
+    });
+  });
+});

--- a/test/textarea-element/form-control-inside-label.test.tsx
+++ b/test/textarea-element/form-control-inside-label.test.tsx
@@ -1,0 +1,94 @@
+import { createFormGroup, formGroup } from '../../src';
+import { screen, render, fireEvent } from 'solid-testing-library';
+import userEvent from '@testing-library/user-event';
+import getRandomString from '../utils/get-random-string';
+
+const INIT_INPUT_VALUE = getRandomString() as string | null;
+const TEST_INPUT_VALUE = getRandomString();
+const NULL = String(null);
+
+const TestApp = () => {
+  const fg = createFormGroup({
+    valueString: INIT_INPUT_VALUE,
+    valueNull: null,
+  });
+  const [form, setForm] = fg.value;
+
+  return (
+    <>
+      <p data-testid="value">{form().valueString}</p>
+      <p data-testid="value-null">{String(form().valueNull)}</p>
+      <form use:formGroup={fg}>
+        <label for="valueString">
+          valueString
+          <textarea data-testid="input" name="valueString" id="valueString" formControlName="valueString" />
+        </label>
+        <label for="valueNull">
+          valueNull
+          <textarea data-testid="input-null" name="valueNull" id="valueNull" formControlName="valueNull" />
+        </label>
+      </form>
+      <button data-testid="btn" onClick={() => setForm((s) => ({ ...s, valueString: TEST_INPUT_VALUE }))}>
+        Change valueString
+      </button>
+      <button data-testid="btn-null" onClick={() => setForm((s) => ({ ...s, valueString: null }))}>
+        Change valueString to null
+      </button>
+    </>
+  );
+};
+
+describe('Label with `textarea` element as child', () => {
+  let $valueString: HTMLElement;
+  let $valueNull: HTMLElement;
+  let $inputWithString: HTMLTextAreaElement;
+  let $inputWithNull: HTMLTextAreaElement;
+  let $changeToStringButton: HTMLElement;
+  let $changeToNullButton: HTMLElement;
+
+  beforeEach(async () => {
+    render(() => <TestApp />);
+
+    $valueString = await screen.findByTestId('value');
+    $valueNull = await screen.findByTestId('value-null');
+    $inputWithString = (await screen.findByTestId('input')) as HTMLTextAreaElement;
+    $inputWithNull = (await screen.findByTestId('input-null')) as HTMLTextAreaElement;
+    $changeToStringButton = await screen.findByTestId('btn');
+    $changeToNullButton = await screen.findByTestId('btn-null');
+  });
+
+  describe('should init value with the one provided in createFormGroup', () => {
+    it('when value is string', () => {
+      expect($valueString.innerHTML).toBe(INIT_INPUT_VALUE);
+      expect($inputWithString.value).toBe(INIT_INPUT_VALUE);
+    });
+
+    it('when value is null', () => {
+      expect($valueNull.innerHTML).toBe(NULL);
+      expect($inputWithNull.value).toBe('');
+    });
+  });
+
+  describe('should update form value when updating programmatically from outside the form', () => {
+    it('with string', () => {
+      userEvent.click($changeToStringButton);
+
+      expect($valueString.innerHTML).toBe(TEST_INPUT_VALUE);
+      expect($inputWithString.value).toBe(TEST_INPUT_VALUE);
+    });
+
+    it('with null', () => {
+      userEvent.click($changeToNullButton);
+
+      expect($valueString.innerHTML === NULL || $valueString.innerHTML === '').toBeTruthy();
+      expect($inputWithString.value).toBe('');
+    });
+  });
+
+  it('should update form value when on manual input', () => {
+    fireEvent.change($inputWithString, { target: { value: '' } });
+    userEvent.type($inputWithString, TEST_INPUT_VALUE);
+
+    expect($valueString.innerHTML).toBe(TEST_INPUT_VALUE);
+  });
+});

--- a/test/textarea-element/form-control-touched-all.test.tsx
+++ b/test/textarea-element/form-control-touched-all.test.tsx
@@ -1,0 +1,105 @@
+import { createFormGroup, formGroup } from '../../src';
+import { screen, render, fireEvent } from 'solid-testing-library';
+import userEvent from '@testing-library/user-event';
+import getRandomString from '../utils/get-random-string';
+
+const INIT_VALUE = getRandomString();
+
+const TestApp = () => {
+  const fg = createFormGroup({
+    value1: INIT_VALUE,
+    value2: {
+      value21: INIT_VALUE,
+    },
+  });
+  const [touched, setTouched] = fg.touched;
+  const [touchedAll, setTouchedAll] = fg.touchedAll;
+
+  return (
+    <>
+      <p data-testid="value-touchedAll">{JSON.stringify(touchedAll())}</p>
+
+      <form use:formGroup={fg}>
+        <label for="value1">value1</label>
+        <textarea data-testid="input-value1" name="value1" id="value1" formControlName="value1" />
+
+        <div formGroupName="value2">
+          <label for="value21">value21</label>
+          <textarea data-testid="input-value21" name="value21" id="value21" formControlName="value21" />
+        </div>
+      </form>
+
+      <button data-testid="btn-mark-all-touched" onClick={() => setTouchedAll(true)}>
+        Mark all as touched
+      </button>
+      <button data-testid="btn-mark-all-untouched" onClick={() => setTouchedAll(false)}>
+        Mark all as untouched
+      </button>
+      <button
+        data-testid="btn-mark-each-touched"
+        onClick={() => setTouched({ ...touched(), value1: true, value2: { value21: true } })}
+      >
+        Mark each as touched
+      </button>
+    </>
+  );
+};
+
+describe('Marking all form controls and groups as touched or untouched for `textarea` element', () => {
+  let $valueTouchedAll: HTMLElement;
+  let $inputValue1: HTMLInputElement;
+  let $inputValue21: HTMLInputElement;
+  let $btnMarkAllTouched: HTMLElement;
+  let $btnMarkAllUntouched: HTMLElement;
+  let $btnMarkEachTouched: HTMLElement;
+
+  beforeEach(async () => {
+    render(() => <TestApp />);
+
+    $valueTouchedAll = await screen.findByTestId('value-touchedAll');
+    $inputValue1 = (await screen.findByTestId('input-value1')) as HTMLInputElement;
+    $inputValue21 = (await screen.findByTestId('input-value21')) as HTMLInputElement;
+    $btnMarkAllTouched = await screen.findByTestId('btn-mark-all-touched');
+    $btnMarkAllUntouched = await screen.findByTestId('btn-mark-all-untouched');
+    $btnMarkEachTouched = await screen.findByTestId('btn-mark-each-touched');
+  });
+
+  it('should read touchedAll value as "false" initially', () => {
+    expect($valueTouchedAll.innerHTML).toBe(String(false));
+  });
+
+  it('should read touchedAll value as "false" when not all form controls are touched', () => {
+    fireEvent.focus($inputValue1);
+    fireEvent.blur($inputValue1);
+
+    expect($valueTouchedAll.innerHTML).toBe(String(false));
+  });
+
+  it('should read touchedAll value as "true" when all controls had blur event dispatched', () => {
+    fireEvent.focus($inputValue1);
+    fireEvent.blur($inputValue1);
+    fireEvent.focus($inputValue21);
+    fireEvent.blur($inputValue21);
+
+    expect($valueTouchedAll.innerHTML).toBe(String(true));
+  });
+
+  it('should read touchedAll value as "true" when all controls were marked as touched programmatically from outside the form', () => {
+    userEvent.click($btnMarkEachTouched);
+
+    expect($valueTouchedAll.innerHTML).toBe(String(true));
+  });
+
+  it('should mark all form controls as touched when setting the property programmatically from outside the form', () => {
+    userEvent.click($btnMarkAllTouched);
+
+    expect($valueTouchedAll.innerHTML).toBe(String(true));
+  });
+
+  it('should read touchedAll value as "false" when setting the touched property programmatically to "false" from outside the form', () => {
+    userEvent.click($btnMarkAllTouched);
+    userEvent.click($btnMarkAllUntouched);
+
+    expect($valueTouchedAll.innerHTML).toBe(String(false));
+  });
+});

--- a/test/textarea-element/form-control-touched.test.tsx
+++ b/test/textarea-element/form-control-touched.test.tsx
@@ -1,0 +1,107 @@
+import { createFormGroup, formGroup } from '../../src';
+import { screen, render, fireEvent } from 'solid-testing-library';
+import userEvent from '@testing-library/user-event';
+import getRandomString from '../utils/get-random-string';
+
+const INIT_VALUE = getRandomString();
+
+const TestApp = () => {
+  const fg = createFormGroup({
+    value1: INIT_VALUE,
+    value2: {
+      value21: INIT_VALUE,
+    },
+  });
+  const [touched, setTouched] = fg.touched;
+
+  return (
+    <>
+      <p data-testid="touched1">{String(touched().value1)}</p>
+      <p data-testid="touched21">{String(touched().value2.value21)}</p>
+
+      <form use:formGroup={fg}>
+        <label for="value1">value1</label>
+        <textarea data-testid="input-value1" name="value1" id="value1" formControlName="value1" />
+
+        <div formGroupName="value2">
+          <label for="value21">value21</label>
+          <textarea data-testid="input-value21" name="value21" id="value21" formControlName="value21" />
+        </div>
+      </form>
+
+      <button
+        data-testid="btn-mark-touched-value1"
+        onClick={() => setTouched({ ...touched(), value1: true })}
+      >
+        Mark value1 touched
+      </button>
+
+      <button
+        data-testid="btn-mark-touched-value21"
+        onClick={() => setTouched({ ...touched(), value2: { value21: true } })}
+      >
+        Mark value21 touched
+      </button>
+    </>
+  );
+};
+
+describe('Reading and marking form controls and groups as touched or untouched', () => {
+  let $touched1: HTMLElement;
+  let $touched21: HTMLElement;
+  let $inputValue1: HTMLTextAreaElement;
+  let $inputValue21: HTMLTextAreaElement;
+  let $btnMarkTouchedValue1: HTMLElement;
+  let $btnMarTouchedValue21: HTMLElement;
+
+  beforeEach(async () => {
+    render(() => <TestApp />);
+
+    $touched1 = await screen.findByTestId('touched1');
+    $touched21 = await screen.findByTestId('touched21');
+    $inputValue1 = (await screen.findByTestId('input-value1')) as HTMLTextAreaElement;
+    $inputValue21 = (await screen.findByTestId('input-value21')) as HTMLTextAreaElement;
+    $btnMarkTouchedValue1 = await screen.findByTestId('btn-mark-touched-value1');
+    $btnMarTouchedValue21 = await screen.findByTestId('btn-mark-touched-value21');
+  });
+
+  describe('should set control as untouched when initialized', () => {
+    it('for top-level control', () => {
+      expect($touched1.innerHTML).toBe(String(false));
+    });
+
+    it('for nested control', () => {
+      expect($touched21.innerHTML).toBe(String(false));
+    });
+  });
+
+  describe('should change control to dirty when form control loses focus (blur event)', () => {
+    it('for top-level control', () => {
+      fireEvent.focus($inputValue1);
+      fireEvent.blur($inputValue1);
+
+      expect($touched1.innerHTML).toBe(String(true));
+    });
+
+    it('for nested control', () => {
+      fireEvent.focus($inputValue21);
+      fireEvent.blur($inputValue21);
+
+      expect($touched21.innerHTML).toBe(String(true));
+    });
+  });
+
+  describe('should change control to touched when changed programmatically from outside the form', () => {
+    it('for top-level control', () => {
+      userEvent.click($btnMarkTouchedValue1);
+
+      expect($touched1.innerHTML).toBe(String(true));
+    });
+
+    it('for nested control', () => {
+      userEvent.click($btnMarTouchedValue21);
+
+      expect($touched21.innerHTML).toBe(String(true));
+    });
+  });
+});

--- a/test/textarea-element/form-control-valid-all.test.tsx
+++ b/test/textarea-element/form-control-valid-all.test.tsx
@@ -1,0 +1,106 @@
+import { createFormGroup, formGroup, Validators as V } from '../../src';
+import { screen, render } from 'solid-testing-library';
+import userEvent from '@testing-library/user-event';
+
+const INIT_STRING_VALUE = '';
+const TEST_STRING_VALUE = 'test';
+
+const TRUE = String(true);
+const FALSE = String(false);
+
+const TestApp = () => {
+  const fg = createFormGroup({
+    value1: INIT_STRING_VALUE,
+    value2: [INIT_STRING_VALUE, { validators: [V.required] }],
+    value4: {
+      value41: INIT_STRING_VALUE,
+      value42: [INIT_STRING_VALUE, { validators: [V.required] }],
+    },
+  });
+  const [form, setForm] = fg.value;
+  const validAll = fg.validAll;
+
+  return (
+    <>
+      <p data-testid="valid-all">{String(validAll())}</p>
+
+      <form use:formGroup={fg}>
+        <label for="value1">value1</label>
+        <textarea data-testid="input-value1" name="value1" id="value1" formControlName="value1" />
+
+        <label for="value2">value2</label>
+        <textarea data-testid="input-value2" name="value2" id="value2" formControlName="value2" />
+
+        <div formGroupName="value4">
+          <label for="value41">value41</label>
+          <textarea data-testid="input-value41" name="value41" id="value41" formControlName="value41" />
+
+          <label for="value42">value42</label>
+          <textarea data-testid="input-value42" name="value42" id="value42" formControlName="value42" />
+        </div>
+      </form>
+
+      <button
+        data-testid="btn-change-value1"
+        onClick={() => setForm({ ...form(), value1: TEST_STRING_VALUE })}
+      >
+        Change value1
+      </button>
+      <button
+        data-testid="btn-change-value2"
+        onClick={() => setForm({ ...form(), value2: TEST_STRING_VALUE })}
+      >
+        Change value2
+      </button>
+
+      <button
+        data-testid="btn-change-value41"
+        onClick={() => setForm({ ...form(), value4: { ...form().value4, value41: TEST_STRING_VALUE } })}
+      >
+        Change value41
+      </button>
+      <button
+        data-testid="btn-change-value42"
+        onClick={() => setForm({ ...form(), value4: { ...form().value4, value42: TEST_STRING_VALUE } })}
+      >
+        Change value42
+      </button>
+    </>
+  );
+};
+
+describe('Reading and marking form controls and groups as touched or untouched for `textarea` element', () => {
+  let $validAll: HTMLElement;
+  let $inputValue2: HTMLTextAreaElement;
+  let $inputValue42: HTMLTextAreaElement;
+  let $btnChangeValue2: HTMLElement;
+  let $btnChangeValue42: HTMLElement;
+
+  beforeEach(async () => {
+    render(() => <TestApp />);
+
+    $validAll = await screen.findByTestId('valid-all');
+    $inputValue2 = (await screen.findByTestId('input-value2')) as HTMLTextAreaElement;
+    $inputValue42 = (await screen.findByTestId('input-value42')) as HTMLTextAreaElement;
+    $btnChangeValue2 = await screen.findByTestId('btn-change-value2');
+    $btnChangeValue42 = await screen.findByTestId('btn-change-value42');
+  });
+
+  it('should mark "validAll" as "false" when at least one form control is invalid', function () {
+    expect($validAll.innerHTML).toBe(FALSE);
+  });
+
+  it('should mark form group as valid when form control values are changed to valid programmatically from outside the form', function () {
+    userEvent.click($btnChangeValue2);
+    userEvent.click($btnChangeValue42);
+
+    expect($validAll.innerHTML).toBe(TRUE);
+  });
+
+  it('should mark form group as valid when form control values are changed from UI to valid ones', function () {
+    userEvent.type($inputValue2, TEST_STRING_VALUE);
+    userEvent.type($inputValue42, TEST_STRING_VALUE);
+
+    expect($validAll.innerHTML).toBe(TRUE);
+  });
+});

--- a/test/textarea-element/form-control-validation-errors.test.tsx
+++ b/test/textarea-element/form-control-validation-errors.test.tsx
@@ -1,0 +1,202 @@
+import { createFormGroup, formGroup, Validators as V } from '../../src';
+import { screen, render } from 'solid-testing-library';
+import userEvent from '@testing-library/user-event';
+
+const INIT_STRING_VALUE = '';
+const TEST_STRING_VALUE = 'test';
+
+const TestApp = () => {
+  const fg = createFormGroup({
+    value1: INIT_STRING_VALUE,
+    value2: [INIT_STRING_VALUE, { validators: [V.required] }],
+    value4: {
+      value41: INIT_STRING_VALUE,
+      value42: [INIT_STRING_VALUE, { validators: [V.required] }],
+    },
+  });
+  const [form, setForm] = fg.value;
+  const errors = fg.errors;
+
+  return (
+    <>
+      <p data-testid="errors-value1">{JSON.stringify(errors().value1)}</p>
+      <p data-testid="errors-value2">{JSON.stringify(errors().value2)}</p>
+      <p data-testid="errors-value41">{JSON.stringify(errors().value4.value41)}</p>
+      <p data-testid="errors-value42">{JSON.stringify(errors().value4.value42)}</p>
+
+      <form use:formGroup={fg}>
+        <label for="value1">value1</label>
+        <input data-testid="input-value1" id="value1" type="text" formControlName="value1" />
+
+        <label for="value2">value2</label>
+        <input data-testid="input-value2" id="value2" type="text" formControlName="value2" />
+
+        <div formGroupName="value4">
+          <label for="value41">value41</label>
+          <input data-testid="input-value41" id="value41" type="text" formControlName="value41" />
+
+          <label for="value42">value42</label>
+          <input data-testid="input-value42" id="value42" type="text" formControlName="value42" />
+        </div>
+      </form>
+
+      <button
+        data-testid="btn-change-value1"
+        onClick={() => setForm({ ...form(), value1: TEST_STRING_VALUE })}
+      >
+        Change value1
+      </button>
+      <button
+        data-testid="btn-change-value2"
+        onClick={() => setForm({ ...form(), value2: TEST_STRING_VALUE })}
+      >
+        Change value2
+      </button>
+
+      <button
+        data-testid="btn-change-value41"
+        onClick={() => setForm({ ...form(), value4: { ...form().value4, value41: TEST_STRING_VALUE } })}
+      >
+        Change value41
+      </button>
+      <button
+        data-testid="btn-change-value42"
+        onClick={() => setForm({ ...form(), value4: { ...form().value4, value42: TEST_STRING_VALUE } })}
+      >
+        Change value42
+      </button>
+    </>
+  );
+};
+
+describe('Reading and marking form controls and groups as touched or untouched', () => {
+  let $errorsValue1: HTMLElement;
+  let $errorsValue2: HTMLElement;
+  let $errorsValue41: HTMLElement;
+  let $errorsValue42: HTMLElement;
+  let $inputValue1: HTMLInputElement;
+  let $inputValue2: HTMLInputElement;
+  let $inputValue41: HTMLInputElement;
+  let $inputValue42: HTMLInputElement;
+  let $btnChangeValue1: HTMLElement;
+  let $btnChangeValue2: HTMLElement;
+  let $btnChangeValue41: HTMLElement;
+  let $btnChangeValue42: HTMLElement;
+
+  beforeEach(async () => {
+    render(() => <TestApp />);
+
+    $errorsValue1 = await screen.findByTestId('errors-value1');
+    $errorsValue2 = await screen.findByTestId('errors-value2');
+    $errorsValue41 = await screen.findByTestId('errors-value41');
+    $errorsValue42 = await screen.findByTestId('errors-value42');
+    $inputValue1 = (await screen.findByTestId('input-value1')) as HTMLInputElement;
+    $inputValue2 = (await screen.findByTestId('input-value2')) as HTMLInputElement;
+    $inputValue41 = (await screen.findByTestId('input-value41')) as HTMLInputElement;
+    $inputValue42 = (await screen.findByTestId('input-value42')) as HTMLInputElement;
+    $btnChangeValue1 = await screen.findByTestId('btn-change-value1');
+    $btnChangeValue2 = await screen.findByTestId('btn-change-value2');
+    $btnChangeValue41 = await screen.findByTestId('btn-change-value41');
+    $btnChangeValue42 = await screen.findByTestId('btn-change-value42');
+  });
+
+  describe('should already show validation errors on init', () => {
+    describe('for top-level controls', () => {
+      it('should show no errors when there is no validators provided in the config', () => {
+        const errors = JSON.parse($errorsValue1.innerHTML);
+
+        expect(errors).toBe(null);
+      });
+
+      it('should show errors when there is one validator that fails', () => {
+        const errors = JSON.parse($errorsValue2.innerHTML);
+
+        expect(errors).not.toBe(null);
+        expect(Object.keys(errors)).toContain('required');
+      });
+    });
+
+    describe('for nested controls', () => {
+      it('should show no errors when there is no validators provided in the config', () => {
+        const errors = JSON.parse($errorsValue41.innerHTML);
+
+        expect(errors).toBe(null);
+      });
+
+      it('should show errors when there is one validator that fails', () => {
+        const errors = JSON.parse($errorsValue42.innerHTML);
+
+        expect(errors).not.toBe(null);
+        expect(Object.keys(errors)).toContain('required');
+      });
+    });
+  });
+
+  describe('should show no errors when form control values are changed to valid programmatically from outside the form', () => {
+    describe('for top-level controls', () => {
+      it('value is changed from valid to valid', () => {
+        userEvent.click($btnChangeValue1);
+        const errors = JSON.parse($errorsValue1.innerHTML);
+
+        expect(errors).toBe(null);
+      });
+
+      it('value is changed from invalid to valid when there is one validator', () => {
+        userEvent.click($btnChangeValue2);
+        const errors = JSON.parse($errorsValue2.innerHTML);
+
+        expect(errors).toBe(null);
+      });
+    });
+
+    describe('for nested controls', () => {
+      it('value is changed from valid to valid', () => {
+        userEvent.click($btnChangeValue41);
+        const errors = JSON.parse($errorsValue41.innerHTML);
+
+        expect(errors).toBe(null);
+      });
+
+      it('value is changed from invalid to valid when there is one validator', () => {
+        userEvent.click($btnChangeValue42);
+        const errors = JSON.parse($errorsValue42.innerHTML);
+
+        expect(errors).toBe(null);
+      });
+    });
+  });
+
+  describe('should show no errors when form control values are changed to valid from UI', () => {
+    describe('for top-level controls', () => {
+      it('value is changed from valid to valid', () => {
+        userEvent.type($inputValue1, TEST_STRING_VALUE);
+        const errors = JSON.parse($errorsValue1.innerHTML);
+
+        expect(errors).toBe(null);
+      });
+
+      it('value is changed from invalid to valid when there is one validator', () => {
+        userEvent.type($inputValue2, TEST_STRING_VALUE);
+        const errors = JSON.parse($errorsValue2.innerHTML);
+
+        expect(errors).toBe(null);
+      });
+    });
+
+    describe('for nested controls', () => {
+      it('value is changed from valid to valid', () => {
+        userEvent.type($inputValue41, TEST_STRING_VALUE);
+        const errors = JSON.parse($errorsValue41.innerHTML);
+
+        expect(errors).toBe(null);
+      });
+
+      it('value is changed from invalid to valid when there is one validator', () => {
+        userEvent.type($inputValue42, TEST_STRING_VALUE);
+        const errors = JSON.parse($errorsValue42.innerHTML);
+
+        expect(errors).toBe(null);
+      });
+    });
+  });
+});

--- a/test/textarea-element/form-control-validators-and-valid.test.tsx
+++ b/test/textarea-element/form-control-validators-and-valid.test.tsx
@@ -1,0 +1,187 @@
+import { createFormGroup, formGroup, Validators as V } from '../../src';
+import { screen, render } from 'solid-testing-library';
+import userEvent from '@testing-library/user-event';
+
+const INIT_STRING_VALUE = '';
+const TEST_STRING_VALUE = 'test';
+
+const TRUE = String(true);
+const FALSE = String(false);
+
+const TestApp = () => {
+  const fg = createFormGroup({
+    value1: INIT_STRING_VALUE,
+    value2: [INIT_STRING_VALUE, { validators: [V.required] }],
+    value4: {
+      value41: INIT_STRING_VALUE,
+      value42: [INIT_STRING_VALUE, { validators: [V.required] }],
+    },
+  });
+  const [form, setForm] = fg.value;
+  const valid = fg.valid;
+
+  return (
+    <>
+      <p data-testid="valid-value1">{String(valid().value1)}</p>
+      <p data-testid="valid-value2">{String(valid().value2)}</p>
+      <p data-testid="valid-value41">{String(valid().value4.value41)}</p>
+      <p data-testid="valid-value42">{String(valid().value4.value42)}</p>
+
+      <form use:formGroup={fg}>
+        <label for="value1">value1</label>
+        <input data-testid="input-value1" id="value1" type="text" formControlName="value1" />
+
+        <label for="value2">value2</label>
+        <input data-testid="input-value2" id="value2" type="text" formControlName="value2" />
+
+        <div formGroupName="value4">
+          <label for="value41">value41</label>
+          <input data-testid="input-value41" id="value41" type="text" formControlName="value41" />
+
+          <label for="value42">value42</label>
+          <input data-testid="input-value42" id="value42" type="text" formControlName="value42" />
+        </div>
+      </form>
+
+      <button
+        data-testid="btn-change-value1"
+        onClick={() => setForm({ ...form(), value1: TEST_STRING_VALUE })}
+      >
+        Change value1
+      </button>
+      <button
+        data-testid="btn-change-value2"
+        onClick={() => setForm({ ...form(), value2: TEST_STRING_VALUE })}
+      >
+        Change value2
+      </button>
+
+      <button
+        data-testid="btn-change-value41"
+        onClick={() => setForm({ ...form(), value4: { ...form().value4, value41: TEST_STRING_VALUE } })}
+      >
+        Change value41
+      </button>
+      <button
+        data-testid="btn-change-value42"
+        onClick={() => setForm({ ...form(), value4: { ...form().value4, value42: TEST_STRING_VALUE } })}
+      >
+        Change value42
+      </button>
+    </>
+  );
+};
+
+describe('Reading and marking form controls and groups as touched or untouched for `textarea` element', () => {
+  let $validValue1: HTMLElement;
+  let $validValue2: HTMLElement;
+  let $validValue41: HTMLElement;
+  let $validValue42: HTMLElement;
+  let $inputValue1: HTMLTextAreaElement;
+  let $inputValue2: HTMLTextAreaElement;
+  let $inputValue41: HTMLTextAreaElement;
+  let $inputValue42: HTMLTextAreaElement;
+  let $btnChangeValue1: HTMLElement;
+  let $btnChangeValue2: HTMLElement;
+  let $btnChangeValue41: HTMLElement;
+  let $btnChangeValue42: HTMLElement;
+
+  beforeEach(async () => {
+    render(() => <TestApp />);
+
+    $validValue1 = await screen.findByTestId('valid-value1');
+    $validValue2 = await screen.findByTestId('valid-value2');
+    $validValue41 = await screen.findByTestId('valid-value41');
+    $validValue42 = await screen.findByTestId('valid-value42');
+    $inputValue1 = (await screen.findByTestId('input-value1')) as HTMLTextAreaElement;
+    $inputValue2 = (await screen.findByTestId('input-value2')) as HTMLTextAreaElement;
+    $inputValue41 = (await screen.findByTestId('input-value41')) as HTMLTextAreaElement;
+    $inputValue42 = (await screen.findByTestId('input-value42')) as HTMLTextAreaElement;
+    $btnChangeValue1 = await screen.findByTestId('btn-change-value1');
+    $btnChangeValue2 = await screen.findByTestId('btn-change-value2');
+    $btnChangeValue41 = await screen.findByTestId('btn-change-value41');
+    $btnChangeValue42 = await screen.findByTestId('btn-change-value42');
+  });
+
+  describe('should already mark form controls as valid/invalid on init', () => {
+    describe('for top-level controls', () => {
+      it('should mark form control as valid when there is no validators provided in the config', () => {
+        expect($validValue1.innerHTML).toBe(TRUE);
+      });
+
+      it('should mark form control as invalid when there is one validator that fails', () => {
+        expect($validValue2.innerHTML).toBe(FALSE);
+      });
+    });
+
+    describe('for nested controls', () => {
+      it('should mark form control as valid when there is no validators provided in the config', () => {
+        expect($validValue41.innerHTML).toBe(TRUE);
+      });
+
+      it('should mark form control as invalid when there is one validator that fails', () => {
+        expect($validValue42.innerHTML).toBe(FALSE);
+      });
+    });
+  });
+
+  describe('should mark form controls as valid when form control values are changed to valid programmatically from outside the form', () => {
+    describe('for top-level controls', () => {
+      it('value is changed from valid to valid', () => {
+        userEvent.click($btnChangeValue1);
+
+        expect($validValue1.innerHTML).toBe(TRUE);
+      });
+
+      it('value is changed from invalid to valid when there is one validator', () => {
+        userEvent.click($btnChangeValue2);
+
+        expect($validValue2.innerHTML).toBe(TRUE);
+      });
+    });
+
+    describe('for nested controls', () => {
+      it('value is changed from valid to valid', () => {
+        userEvent.click($btnChangeValue41);
+
+        expect($validValue41.innerHTML).toBe(TRUE);
+      });
+
+      it('value is changed from invalid to valid when there is one validator', () => {
+        userEvent.click($btnChangeValue42);
+
+        expect($validValue42.innerHTML).toBe(TRUE);
+      });
+    });
+  });
+
+  describe('should mark form controls as valid when form control values are changed from UI', () => {
+    describe('for top-level controls', () => {
+      it('value is changed from valid to valid', () => {
+        userEvent.type($inputValue1, TEST_STRING_VALUE);
+
+        expect($validValue1.innerHTML).toBe(TRUE);
+      });
+
+      it('value is changed from invalid to valid when there is one validator', () => {
+        userEvent.type($inputValue2, TEST_STRING_VALUE);
+
+        expect($validValue2.innerHTML).toBe(TRUE);
+      });
+    });
+
+    describe('for nested controls', () => {
+      it('value is changed from valid to valid', () => {
+        userEvent.type($inputValue41, TEST_STRING_VALUE);
+
+        expect($validValue41.innerHTML).toBe(TRUE);
+      });
+
+      it('value is changed from invalid to valid when there is one validator', () => {
+        userEvent.type($inputValue42, TEST_STRING_VALUE);
+
+        expect($validValue42.innerHTML).toBe(TRUE);
+      });
+    });
+  });
+});

--- a/test/textarea-element/form-control-value.test.tsx
+++ b/test/textarea-element/form-control-value.test.tsx
@@ -1,0 +1,92 @@
+import { createFormGroup, formGroup } from '../../src';
+import { screen, render, fireEvent } from 'solid-testing-library';
+import userEvent from '@testing-library/user-event';
+
+const INIT_INPUT_VALUE = 'Thomas' as string | null;
+const TEST_INPUT_VALUE = 'test';
+const NULL = String(null);
+
+const TestApp = () => {
+  const fg = createFormGroup({
+    valueString: INIT_INPUT_VALUE,
+    valueNull: null,
+  });
+  const [form, setForm] = fg.value;
+
+  return (
+    <>
+      <p data-testid="value">{form().valueString}</p>
+      <p data-testid="value-null">{String(form().valueNull)}</p>
+
+      <form use:formGroup={fg}>
+        <label for="valueString">valueString</label>
+        <textarea data-testid="input" name="valueString" id="valueString" formControlName="valueString" />
+
+        <label for="valueNull">First name null</label>
+        <textarea data-testid="input-null" name="valueNull" id="valueNull" formControlName="valueNull" />
+      </form>
+
+      <button data-testid="btn" onClick={() => setForm((s) => ({ ...s, valueString: TEST_INPUT_VALUE }))}>
+        Change valueString
+      </button>
+      <button data-testid="btn-null" onClick={() => setForm((s) => ({ ...s, valueString: null }))}>
+        Change valueString to null
+      </button>
+    </>
+  );
+};
+
+describe('Values for `textarea` elements', () => {
+  let $valueString: HTMLElement;
+  let $valueNull: HTMLElement;
+  let $inputWithString: HTMLTextAreaElement;
+  let $inputWithNull: HTMLTextAreaElement;
+  let $changeToStringButton: HTMLElement;
+  let $changeToNullButton: HTMLElement;
+
+  beforeEach(async () => {
+    render(() => <TestApp />);
+
+    $valueString = await screen.findByTestId('value');
+    $valueNull = await screen.findByTestId('value-null');
+    $inputWithString = (await screen.findByTestId('input')) as HTMLTextAreaElement;
+    $inputWithNull = (await screen.findByTestId('input-null')) as HTMLTextAreaElement;
+    $changeToStringButton = await screen.findByTestId('btn');
+    $changeToNullButton = await screen.findByTestId('btn-null');
+  });
+
+  describe('should init value with the one provided in createFormGroup', () => {
+    it('when value is string', () => {
+      expect($valueString.innerHTML).toBe(INIT_INPUT_VALUE);
+      expect($inputWithString.value).toBe(INIT_INPUT_VALUE);
+    });
+
+    it('when value is null', () => {
+      expect($valueNull.innerHTML).toBe(NULL);
+      expect($inputWithNull.value).toBe('');
+    });
+  });
+
+  describe('should update form value when updating programmatically from outside the form', () => {
+    it('with string', () => {
+      userEvent.click($changeToStringButton);
+
+      expect($valueString.innerHTML).toBe(TEST_INPUT_VALUE);
+      expect($inputWithString.value).toBe(TEST_INPUT_VALUE);
+    });
+
+    it('with null', () => {
+      userEvent.click($changeToNullButton);
+
+      expect($valueString.innerHTML === NULL || $valueString.innerHTML === '').toBeTruthy();
+      expect($inputWithString.value).toBe('');
+    });
+  });
+
+  it('should update form value when on manual input', () => {
+    fireEvent.change($inputWithString, { target: { value: '' } });
+    userEvent.type($inputWithString, TEST_INPUT_VALUE);
+
+    expect($valueString.innerHTML).toBe(TEST_INPUT_VALUE);
+  });
+});

--- a/test/textarea-element/form-group-nested.test.tsx
+++ b/test/textarea-element/form-group-nested.test.tsx
@@ -1,0 +1,123 @@
+import { createFormGroup, formGroup } from '../../src';
+import { screen, render, fireEvent } from 'solid-testing-library';
+import userEvent from '@testing-library/user-event';
+import getRandomString from '../utils/get-random-string';
+
+const INIT_INPUT_STRING_VALUE = getRandomString();
+const TEST_INPUT_STRING_VALUE = getRandomString();
+
+const TestApp = () => {
+  const fg = createFormGroup({
+    value: {
+      nested1: INIT_INPUT_STRING_VALUE,
+      nested2: {
+        nested21: INIT_INPUT_STRING_VALUE,
+      },
+    },
+  });
+  const [form, setForm] = fg.value;
+
+  return (
+    <>
+      <p data-testid="value-nested1">{form().value.nested1}</p>
+      <p data-testid="value-nested21">{form().value.nested2.nested21}</p>
+
+      <form use:formGroup={fg}>
+        <div formGroupName="value">
+          <label for="value">First name</label>
+          <textarea data-testid="input-nested1" name="value" id="value" formControlName="nested1" />
+
+          <span formGroupName="nested2">
+            <label for="value">First name</label>
+            <textarea data-testid="input-nested21" name="value" id="value" formControlName="nested21" />
+          </span>
+        </div>
+      </form>
+
+      <button
+        data-testid="btn-nested1"
+        onClick={() => setForm({ ...form(), value: { ...form().value, nested1: TEST_INPUT_STRING_VALUE } })}
+      >
+        Change nested1
+      </button>
+      <button
+        data-testid="btn-nested21"
+        onClick={() =>
+          setForm({
+            ...form(),
+            value: {
+              ...form().value,
+              nested2: { ...form().value.nested2, nested21: TEST_INPUT_STRING_VALUE },
+            },
+          })
+        }
+      >
+        Change nested21
+      </button>
+    </>
+  );
+};
+
+describe('Nested form control with `textarea` elements', () => {
+  let $valueNested1: HTMLElement;
+  let $input1: HTMLTextAreaElement;
+  let $changeNested1Value: HTMLElement;
+  let $valueNested21: HTMLElement;
+  let $input21: HTMLTextAreaElement;
+  let $changeNested21Value: HTMLElement;
+
+  beforeEach(async () => {
+    render(() => <TestApp />);
+
+    $valueNested1 = await screen.findByTestId('value-nested1');
+    $valueNested21 = await screen.findByTestId('value-nested21');
+    $input1 = (await screen.findByTestId('input-nested1')) as HTMLTextAreaElement;
+    $input21 = (await screen.findByTestId('input-nested21')) as HTMLTextAreaElement;
+    $changeNested1Value = await screen.findByTestId('btn-nested1');
+    $changeNested21Value = await screen.findByTestId('btn-nested21');
+  });
+
+  describe('should init value with the one provided in createFormGroup', () => {
+    it('for value nested on lvl 1', () => {
+      expect($valueNested1.innerHTML).toBe(INIT_INPUT_STRING_VALUE);
+      expect($input1.value).toBe(INIT_INPUT_STRING_VALUE);
+    });
+
+    it('for value nested on lvl 2', () => {
+      expect($valueNested21.innerHTML).toBe(INIT_INPUT_STRING_VALUE);
+      expect($input21.value).toBe(INIT_INPUT_STRING_VALUE);
+    });
+  });
+
+  describe('should update form value when updating programmatically from outside the form', () => {
+    it('for value nested on lvl 1', () => {
+      userEvent.click($changeNested1Value);
+
+      expect($valueNested1.innerHTML).toBe(TEST_INPUT_STRING_VALUE);
+      expect($input1.value).toBe(TEST_INPUT_STRING_VALUE);
+    });
+
+    it('for value nested on lvl 2', () => {
+      userEvent.click($changeNested21Value);
+
+      expect($valueNested21.innerHTML).toBe(TEST_INPUT_STRING_VALUE);
+      expect($input21.value).toBe(TEST_INPUT_STRING_VALUE);
+    });
+  });
+
+  describe('should update form value when on manual input', () => {
+    it('for value nested on lvl 1', () => {
+      fireEvent.change($input1, { target: { value: '' } });
+      userEvent.type($input1, TEST_INPUT_STRING_VALUE);
+
+      expect($valueNested1.innerHTML).toBe(TEST_INPUT_STRING_VALUE);
+    });
+
+    it('for value nested on lvl 2', () => {
+      fireEvent.change($input21, { target: { value: '' } });
+      userEvent.type($input21, TEST_INPUT_STRING_VALUE);
+
+      expect($valueNested21.innerHTML).toBe(TEST_INPUT_STRING_VALUE);
+    });
+  });
+});


### PR DESCRIPTION
Added support for `<textarea>` element: 
- updated `formGroup` directive to support `<textarea>` element
  + Support null as an empty value for all form control
  + Support `textarea` elements inside label elements
  + Support nested form groups
  + Support `disabled`, `touched` and `dirty` form control properties for `textarea` element
  + Support `disabledAll`, `touchedAll` and `dirtyAll` form group properties that include `textarea` element
  + Support adding validators to `textarea` element
  + Support `valid` and `validAll` for `textarea` element
  + Added errors form control property for accessing validation errors for `textarea` element
- added tests for all above cases
- updated docs